### PR TITLE
Implement Taiko Difficulty Calculator

### DIFF
--- a/MapsetParser.xml
+++ b/MapsetParser.xml
@@ -444,6 +444,26 @@
         <member name="M:MapsetParser.objects.Osb.IsUsed">
             <summary> Returns whether the .osb file is actually used as a storyboard (or if it's just empty). </summary>
         </member>
+        <member name="F:MapsetParser.objects.taiko.Hit.Type">
+            <summary>
+            The <see cref="T:MapsetParser.objects.taiko.HitType"/> that actuates this <see cref="T:MapsetParser.objects.taiko.Hit"/>.
+            </summary>
+        </member>
+        <member name="T:MapsetParser.objects.taiko.HitType">
+            <summary>
+            The type of a <see cref="T:MapsetParser.objects.taiko.Hit"/>.
+            </summary>
+        </member>
+        <member name="F:MapsetParser.objects.taiko.HitType.Centre">
+            <summary>
+            A <see cref="T:MapsetParser.objects.taiko.Hit"/> that can be hit by the centre portion of the drum.
+            </summary>
+        </member>
+        <member name="F:MapsetParser.objects.taiko.HitType.Rim">
+            <summary>
+            A <see cref="T:MapsetParser.objects.taiko.Hit"/> that can be hit by the rim portion of the drum.
+            </summary>
+        </member>
         <member name="M:MapsetParser.objects.TimingLine.GetOffset(System.String[])">
             <summary> Returns the offset of the line. </summary>
         </member>
@@ -492,6 +512,149 @@
         </member>
         <member name="M:MapsetParser.objects.timinglines.UninheritedLine.GetBPM">
             <summary> Returns the beats per minute (BPM) of the uninherited line. </summary>
+        </member>
+        <member name="F:MapsetParser.scoring.HitResult.None">
+            <summary>
+            Indicates that the object has not been judged yet.
+            </summary>
+        </member>
+        <member name="F:MapsetParser.scoring.HitResult.Miss">
+            <summary>
+            Indicates that the object has been judged as a miss.
+            </summary>
+            <remarks>
+            This miss window should determine how early a hit can be before it is considered for judgement (as opposed to being ignored as
+            "too far in the future). It should also define when a forced miss should be triggered (as a result of no user input in time).
+            </remarks>
+        </member>
+        <member name="F:MapsetParser.scoring.HitResult.Perfect">
+            <summary>
+            This is an optional timing window tighter than <see cref="F:MapsetParser.scoring.HitResult.Great"/>.
+            </summary>
+            <remarks>
+            By default, this does not give any bonus accuracy or score.
+            To have it affect scoring, consider adding a nested bonus object.
+            </remarks>
+        </member>
+        <member name="F:MapsetParser.scoring.HitResult.SmallTickMiss">
+            <summary>
+            Indicates small tick miss.
+            </summary>
+        </member>
+        <member name="F:MapsetParser.scoring.HitResult.SmallTickHit">
+            <summary>
+            Indicates a small tick hit.
+            </summary>
+        </member>
+        <member name="F:MapsetParser.scoring.HitResult.LargeTickMiss">
+            <summary>
+            Indicates a large tick miss.
+            </summary>
+        </member>
+        <member name="F:MapsetParser.scoring.HitResult.LargeTickHit">
+            <summary>
+            Indicates a large tick hit.
+            </summary>
+        </member>
+        <member name="F:MapsetParser.scoring.HitResult.SmallBonus">
+            <summary>
+            Indicates a small bonus.
+            </summary>
+        </member>
+        <member name="F:MapsetParser.scoring.HitResult.LargeBonus">
+            <summary>
+            Indicates a large bonus.
+            </summary>
+        </member>
+        <member name="F:MapsetParser.scoring.HitResult.IgnoreMiss">
+            <summary>
+            Indicates a miss that should be ignored for scoring purposes.
+            </summary>
+        </member>
+        <member name="F:MapsetParser.scoring.HitResult.IgnoreHit">
+            <summary>
+            Indicates a hit that should be ignored for scoring purposes.
+            </summary>
+        </member>
+        <member name="F:MapsetParser.scoring.HitResult.ComboBreak">
+            <summary>
+            Indicates that a combo break should occur, but does not otherwise affect score.
+            </summary>
+            <remarks>
+            May be paired with <see cref="F:MapsetParser.scoring.HitResult.IgnoreHit"/>.
+            </remarks>
+        </member>
+        <member name="F:MapsetParser.scoring.HitResult.LegacyComboIncrease">
+            <summary>
+            A special result used as a padding value for legacy rulesets. It is a hit type and affects combo, but does not affect the base score (does not affect accuracy).
+            </summary>
+            <remarks>
+            DO NOT USE.
+            </remarks>
+        </member>
+        <member name="T:MapsetParser.scoring.HitWindows">
+            <summary>
+            A structure containing timing data for hit window based gameplay.
+            </summary>
+        </member>
+        <member name="P:MapsetParser.scoring.HitWindows.Empty">
+            <summary>
+            An empty <see cref="T:MapsetParser.scoring.HitWindows"/> with only <see cref="F:MapsetParser.scoring.HitResult.Miss"/> and <see cref="F:MapsetParser.scoring.HitResult.Perfect"/>.
+            No time values are provided (meaning instantaneous hit or miss).
+            </summary>
+        </member>
+        <member name="M:MapsetParser.scoring.HitWindows.LowestSuccessfulHitResult">
+            <summary>
+            Retrieves the <see cref="T:MapsetParser.scoring.HitResult"/> with the largest hit window that produces a successful hit.
+            </summary>
+            <returns>The lowest allowed successful <see cref="T:MapsetParser.scoring.HitResult"/>.</returns>
+        </member>
+        <member name="M:MapsetParser.scoring.HitWindows.GetAllAvailableWindows">
+            <summary>
+            Retrieves a mapping of <see cref="T:MapsetParser.scoring.HitResult"/>s to their timing windows for all allowed <see cref="T:MapsetParser.scoring.HitResult"/>s.
+            </summary>
+        </member>
+        <member name="M:MapsetParser.scoring.HitWindows.IsHitResultAllowed(MapsetParser.scoring.HitResult)">
+            <summary>
+            Check whether it is possible to achieve the provided <see cref="T:MapsetParser.scoring.HitResult"/>.
+            </summary>
+            <param name="result">The result type to check.</param>
+            <returns>Whether the <see cref="T:MapsetParser.scoring.HitResult"/> can be achieved.</returns>
+        </member>
+        <member name="M:MapsetParser.scoring.HitWindows.SetDifficulty(System.Double)">
+            <summary>
+            Sets hit windows with values that correspond to a difficulty parameter.
+            </summary>
+            <param name="difficulty">The parameter.</param>
+        </member>
+        <member name="M:MapsetParser.scoring.HitWindows.ResultFor(System.Double)">
+            <summary>
+            Retrieves the <see cref="T:MapsetParser.scoring.HitResult"/> for a time offset.
+            </summary>
+            <param name="timeOffset">The time offset.</param>
+            <returns>The hit result, or <see cref="F:MapsetParser.scoring.HitResult.None"/> if <paramref name="timeOffset"/> doesn't result in a judgement.</returns>
+        </member>
+        <member name="M:MapsetParser.scoring.HitWindows.WindowFor(MapsetParser.scoring.HitResult)">
+            <summary>
+            Retrieves the hit window for a <see cref="T:MapsetParser.scoring.HitResult"/>.
+            This is the number of +/- milliseconds allowed for the requested result (so the actual hittable range is double this).
+            </summary>
+            <param name="result">The expected <see cref="T:MapsetParser.scoring.HitResult"/>.</param>
+            <returns>One half of the hit window for <paramref name="result"/>.</returns>
+        </member>
+        <member name="M:MapsetParser.scoring.HitWindows.CanBeHit(System.Double)">
+            <summary>
+            Given a time offset, whether the <see cref="!:HitObject"/> can ever be hit in the future with a non-<see cref="F:MapsetParser.scoring.HitResult.Miss"/> result.
+            This happens if <paramref name="timeOffset"/> is less than what is required for <see cref="M:MapsetParser.scoring.HitWindows.LowestSuccessfulHitResult"/>.
+            </summary>
+            <param name="timeOffset">The time offset.</param>
+            <returns>Whether the <see cref="!:HitObject"/> can be hit at any point in the future from this time offset.</returns>
+        </member>
+        <member name="M:MapsetParser.scoring.HitWindows.GetRanges">
+            <summary>
+            Retrieve a valid list of <see cref="T:MapsetParser.scoring.DifficultyRange"/>s representing hit windows.
+            Defaults are provided but can be overridden to customise for a ruleset.
+            </summary>
         </member>
         <member name="F:MapsetParser.settings.ColourSettings.combos">
             <summary> Starts at index 0, so combo colour 1 is the 0th element in the list. </summary>
@@ -557,14 +720,12 @@
             <param name="beatmap">The <see cref="!:IBeatmap"/> whose difficulty was calculated.</param>
             <param name="mods">The <see cref="!:Mod"/>s that difficulty was calculated with.</param>
             <param name="skills">The skills which processed the beatmap.</param>
-            <param name="clockRate">The rate at which the gameplay clock is run at.</param>
         </member>
         <member name="M:MapsetParser.starrating.DifficultyCalculator.CreateDifficultyHitObjects(MapsetParser.objects.Beatmap)">
             <summary>
             Enumerates <see cref="T:MapsetParser.starrating.preprocessing.DifficultyHitObject"/>s to be processed from <see cref="T:MapsetParser.objects.HitObject"/>s in the <see cref="!:IBeatmap"/>.
             </summary>
             <param name="beatmap">The <see cref="!:IBeatmap"/> providing the <see cref="T:MapsetParser.objects.HitObject"/>s to enumerate.</param>
-            <param name="clockRate">The rate at which the gameplay clock is run at.</param>
             <returns>The enumerated <see cref="T:MapsetParser.starrating.preprocessing.DifficultyHitObject"/>s.</returns>
         </member>
         <member name="M:MapsetParser.starrating.DifficultyCalculator.CreateSkills(MapsetParser.objects.Beatmap)">
@@ -573,6 +734,87 @@
             </summary>
             <param name="beatmap">The <see cref="!:IBeatmap"/> whose difficulty will be calculated.</param>
             <returns>The <see cref="T:MapsetParser.starrating.skills.Skill"/>s.</returns>
+        </member>
+        <member name="T:MapsetParser.starrating.IBeatmapDifficultyInfo">
+            <summary>
+            A representation of all top-level difficulty settings for a beatmap.
+            </summary>
+        </member>
+        <member name="F:MapsetParser.starrating.IBeatmapDifficultyInfo.DEFAULT_DIFFICULTY">
+            <summary>
+            The default value used for all difficulty settings except <see cref="P:MapsetParser.starrating.IBeatmapDifficultyInfo.SliderMultiplier"/> and <see cref="P:MapsetParser.starrating.IBeatmapDifficultyInfo.SliderTickRate"/>.
+            </summary>
+        </member>
+        <member name="P:MapsetParser.starrating.IBeatmapDifficultyInfo.DrainRate">
+            <summary>
+            The drain rate of the associated beatmap.
+            </summary>
+        </member>
+        <member name="P:MapsetParser.starrating.IBeatmapDifficultyInfo.CircleSize">
+            <summary>
+            The circle size of the associated beatmap.
+            </summary>
+        </member>
+        <member name="P:MapsetParser.starrating.IBeatmapDifficultyInfo.OverallDifficulty">
+            <summary>
+            The overall difficulty of the associated beatmap.
+            </summary>
+        </member>
+        <member name="P:MapsetParser.starrating.IBeatmapDifficultyInfo.ApproachRate">
+            <summary>
+            The approach rate of the associated beatmap.
+            </summary>
+        </member>
+        <member name="P:MapsetParser.starrating.IBeatmapDifficultyInfo.SliderMultiplier">
+            <summary>
+            The base slider velocity of the associated beatmap.
+            This was known as "SliderMultiplier" in the .osu format and stable editor.
+            </summary>
+        </member>
+        <member name="P:MapsetParser.starrating.IBeatmapDifficultyInfo.SliderTickRate">
+            <summary>
+            The slider tick rate of the associated beatmap.
+            </summary>
+        </member>
+        <member name="M:MapsetParser.starrating.IBeatmapDifficultyInfo.DifficultyRange(System.Double,System.Double,System.Double,System.Double)">
+            <summary>
+            Maps a difficulty value [0, 10] to a two-piece linear range of values.
+            </summary>
+            <param name="difficulty">The difficulty value to be mapped.</param>
+            <param name="min">Minimum of the resulting range which will be achieved by a difficulty value of 0.</param>
+            <param name="mid">Midpoint of the resulting range which will be achieved by a difficulty value of 5.</param>
+            <param name="max">Maximum of the resulting range which will be achieved by a difficulty value of 10.</param>
+            <returns>Value to which the difficulty value maps in the specified range.</returns>
+        </member>
+        <member name="M:MapsetParser.starrating.IBeatmapDifficultyInfo.DifficultyRange(System.Double)">
+            <summary>
+            Maps a difficulty value [0, 10] to a linear range of [-1, 1].
+            </summary>
+            <param name="difficulty">The difficulty value to be mapped.</param>
+            <returns>Value to which the difficulty value maps in the specified range.</returns>
+        </member>
+        <member name="M:MapsetParser.starrating.IBeatmapDifficultyInfo.DifficultyRange(System.Double,System.ValueTuple{System.Double,System.Double,System.Double})">
+            <summary>
+            Maps a difficulty value [0, 10] to a two-piece linear range of values.
+            </summary>
+            <param name="difficulty">The difficulty value to be mapped.</param>
+            <param name="range">The values that define the two linear ranges.
+            <list type="table">
+              <item>
+                <term>od0</term>
+                <description>Minimum of the resulting range which will be achieved by a difficulty value of 0.</description>
+              </item>
+              <item>
+                <term>od5</term>
+                <description>Midpoint of the resulting range which will be achieved by a difficulty value of 5.</description>
+              </item>
+              <item>
+                <term>od10</term>
+                <description>Maximum of the resulting range which will be achieved by a difficulty value of 10.</description>
+              </item>
+            </list>
+            </param>
+            <returns>Value to which the difficulty value maps in the specified range.</returns>
         </member>
         <member name="P:MapsetParser.starrating.osu.preprocessing.OsuDifficultyHitObject.JumpDistance">
             <summary>
@@ -610,6 +852,11 @@
             Wraps a <see cref="T:MapsetParser.objects.HitObject"/> and provides additional information to be used for difficulty calculation.
             </summary>
         </member>
+        <member name="F:MapsetParser.starrating.preprocessing.DifficultyHitObject.Index">
+            <summary>
+            The index of this <see cref="T:MapsetParser.starrating.preprocessing.DifficultyHitObject"/> in the list of all <see cref="T:MapsetParser.starrating.preprocessing.DifficultyHitObject"/>s.
+            </summary>
+        </member>
         <member name="F:MapsetParser.starrating.preprocessing.DifficultyHitObject.BaseObject">
             <summary>
             The <see cref="T:MapsetParser.objects.HitObject"/> this <see cref="T:MapsetParser.starrating.preprocessing.DifficultyHitObject"/> wraps.
@@ -625,82 +872,638 @@
             Amount of time elapsed between <see cref="F:MapsetParser.starrating.preprocessing.DifficultyHitObject.BaseObject"/> and <see cref="F:MapsetParser.starrating.preprocessing.DifficultyHitObject.LastObject"/>.
             </summary>
         </member>
-        <member name="M:MapsetParser.starrating.preprocessing.DifficultyHitObject.#ctor(MapsetParser.objects.HitObject,MapsetParser.objects.HitObject)">
+        <member name="F:MapsetParser.starrating.preprocessing.DifficultyHitObject.StartTime">
+            <summary>
+            Start time of <see cref="F:MapsetParser.starrating.preprocessing.DifficultyHitObject.BaseObject"/>.
+            </summary>
+        </member>
+        <member name="F:MapsetParser.starrating.preprocessing.DifficultyHitObject.EndTime">
+            <summary>
+            End time of <see cref="F:MapsetParser.starrating.preprocessing.DifficultyHitObject.BaseObject"/>.
+            </summary>
+        </member>
+        <member name="M:MapsetParser.starrating.preprocessing.DifficultyHitObject.#ctor(MapsetParser.objects.HitObject,MapsetParser.objects.HitObject,System.Collections.Generic.List{MapsetParser.starrating.preprocessing.DifficultyHitObject},System.Int32)">
             <summary>
             Creates a new <see cref="T:MapsetParser.starrating.preprocessing.DifficultyHitObject"/>.
             </summary>
             <param name="hitObject">The <see cref="T:MapsetParser.objects.HitObject"/> which this <see cref="T:MapsetParser.starrating.preprocessing.DifficultyHitObject"/> wraps.</param>
             <param name="lastObject">The last <see cref="T:MapsetParser.objects.HitObject"/> which occurs before <paramref name="hitObject"/> in the beatmap.</param>
-            <param name="clockRate">The rate at which the gameplay clock is run at.</param>
+            <param name="objects">The list of <see cref="T:MapsetParser.starrating.preprocessing.DifficultyHitObject"/>s in the current beatmap.</param>
+            <param name="index">The index of this <see cref="T:MapsetParser.starrating.preprocessing.DifficultyHitObject"/> in <paramref name="objects"/> list.</param>
         </member>
         <member name="T:MapsetParser.starrating.skills.Skill">
+            <summary>
+            A bare minimal abstract skill for fully custom skill implementations.
+            </summary>
+            <remarks>
+            This class should be considered a "processing" class and not persisted.
+            </remarks>
+        </member>
+        <member name="M:MapsetParser.starrating.skills.Skill.Process(MapsetParser.starrating.preprocessing.DifficultyHitObject)">
+            <summary>
+            Process a <see cref="T:MapsetParser.starrating.preprocessing.DifficultyHitObject"/>.
+            </summary>
+            <param name="current">The <see cref="T:MapsetParser.starrating.preprocessing.DifficultyHitObject"/> to process.</param>
+        </member>
+        <member name="M:MapsetParser.starrating.skills.Skill.DifficultyValue">
+            <summary>
+            Returns the calculated difficulty value representing all <see cref="T:MapsetParser.starrating.preprocessing.DifficultyHitObject"/>s that have been processed up to this point.
+            </summary>
+        </member>
+        <member name="T:MapsetParser.starrating.skills.StrainDecaySkill">
             <summary>
             Used to processes strain values of <see cref="T:MapsetParser.starrating.preprocessing.DifficultyHitObject"/>s, keep track of strain levels caused by the processed objects
             and to calculate a final difficulty value representing the difficulty of hitting all the processed objects.
             </summary>
         </member>
-        <member name="P:MapsetParser.starrating.skills.Skill.StrainPeaks">
-            <summary>
-            The peak strain for each <see cref="P:MapsetParser.starrating.DifficultyCalculator.SectionLength"/> section of the beatmap.
-            </summary>
-        </member>
-        <member name="P:MapsetParser.starrating.skills.Skill.SkillMultiplier">
+        <member name="P:MapsetParser.starrating.skills.StrainDecaySkill.SkillMultiplier">
             <summary>
             Strain values are multiplied by this number for the given skill. Used to balance the value of different skills between each other.
             </summary>
         </member>
-        <member name="P:MapsetParser.starrating.skills.Skill.StrainDecayBase">
+        <member name="P:MapsetParser.starrating.skills.StrainDecaySkill.StrainDecayBase">
             <summary>
             Determines how quickly strain decays for the given skill.
             For example a value of 0.15 indicates that strain decays to 15% of its original value in one second.
             </summary>
         </member>
-        <member name="P:MapsetParser.starrating.skills.Skill.DecayWeight">
-            <summary>
-            The weight by which each strain value decays.
-            </summary>
-        </member>
-        <member name="F:MapsetParser.starrating.skills.Skill.Previous">
-            <summary>
-            <see cref="T:MapsetParser.starrating.preprocessing.DifficultyHitObject"/>s that were processed previously. They can affect the strain values of the following objects.
-            </summary>
-        </member>
-        <member name="P:MapsetParser.starrating.skills.Skill.CurrentStrain">
+        <member name="P:MapsetParser.starrating.skills.StrainDecaySkill.CurrentStrain">
             <summary>
             The current strain level.
             </summary>
         </member>
-        <member name="M:MapsetParser.starrating.skills.Skill.Process(MapsetParser.starrating.preprocessing.DifficultyHitObject)">
+        <member name="M:MapsetParser.starrating.skills.StrainDecaySkill.StrainValueOf(MapsetParser.starrating.preprocessing.DifficultyHitObject)">
+            <summary>
+            Calculates the strain value of a <see cref="T:MapsetParser.starrating.preprocessing.DifficultyHitObject"/>. This value is affected by previously processed objects.
+            </summary>
+        </member>
+        <member name="T:MapsetParser.starrating.skills.StrainSkill">
+            <summary>
+            Used to processes strain values of <see cref="T:MapsetParser.starrating.preprocessing.DifficultyHitObject"/>s, keep track of strain levels caused by the processed objects
+            and to calculate a final difficulty value representing the difficulty of hitting all the processed objects.
+            </summary>
+        </member>
+        <member name="P:MapsetParser.starrating.skills.StrainSkill.DecayWeight">
+            <summary>
+            The weight by which each strain value decays.
+            </summary>
+        </member>
+        <member name="P:MapsetParser.starrating.skills.StrainSkill.SectionLength">
+            <summary>
+            The length of each strain section.
+            </summary>
+        </member>
+        <member name="M:MapsetParser.starrating.skills.StrainSkill.StrainValueAt(MapsetParser.starrating.preprocessing.DifficultyHitObject)">
+            <summary>
+            Returns the strain value at <see cref="T:MapsetParser.starrating.preprocessing.DifficultyHitObject"/>. This value is calculated with or without respect to previous objects.
+            </summary>
+        </member>
+        <member name="M:MapsetParser.starrating.skills.StrainSkill.Process(MapsetParser.starrating.preprocessing.DifficultyHitObject)">
             <summary>
             Process a <see cref="T:MapsetParser.starrating.preprocessing.DifficultyHitObject"/> and update current strain values accordingly.
             </summary>
         </member>
-        <member name="M:MapsetParser.starrating.skills.Skill.SaveCurrentPeak">
+        <member name="M:MapsetParser.starrating.skills.StrainSkill.saveCurrentPeak">
             <summary>
             Saves the current peak strain level to the list of strain peaks, which will be used to calculate an overall difficulty.
             </summary>
         </member>
-        <member name="M:MapsetParser.starrating.skills.Skill.StartNewSectionFrom(System.Double)">
+        <member name="M:MapsetParser.starrating.skills.StrainSkill.startNewSectionFrom(System.Double,MapsetParser.starrating.preprocessing.DifficultyHitObject)">
             <summary>
             Sets the initial strain level for a new section.
             </summary>
             <param name="time">The beginning of the new section in milliseconds.</param>
+            <param name="current">The current hit object.</param>
         </member>
-        <member name="M:MapsetParser.starrating.skills.Skill.GetPeakStrain(System.Double)">
+        <member name="M:MapsetParser.starrating.skills.StrainSkill.CalculateInitialStrain(System.Double,MapsetParser.starrating.preprocessing.DifficultyHitObject)">
             <summary>
             Retrieves the peak strain at a point in time.
             </summary>
             <param name="time">The time to retrieve the peak strain at.</param>
+            <param name="current">The current hit object.</param>
             <returns>The peak strain.</returns>
         </member>
-        <member name="M:MapsetParser.starrating.skills.Skill.DifficultyValue">
+        <member name="M:MapsetParser.starrating.skills.StrainSkill.GetCurrentStrainPeaks">
             <summary>
-            Returns the calculated difficulty value representing all processed <see cref="T:MapsetParser.starrating.preprocessing.DifficultyHitObject"/>s.
+            Returns a live enumerable of the peak strains for each <see cref="P:MapsetParser.starrating.skills.StrainSkill.SectionLength"/> section of the beatmap,
+            including the peak of the current section.
             </summary>
         </member>
-        <member name="M:MapsetParser.starrating.skills.Skill.StrainValueOf(MapsetParser.starrating.preprocessing.DifficultyHitObject)">
+        <member name="M:MapsetParser.starrating.skills.StrainSkill.DifficultyValue">
             <summary>
-            Calculates the strain value of a <see cref="T:MapsetParser.starrating.preprocessing.DifficultyHitObject"/>. This value is affected by previously processed objects.
+            Returns the calculated difficulty value representing all <see cref="T:MapsetParser.starrating.preprocessing.DifficultyHitObject"/>s that have been processed up to this point.
+            </summary>
+        </member>
+        <member name="M:MapsetParser.starrating.taiko.evaluators.ColourEvaluator.sigmoid(System.Double,System.Double,System.Double,System.Double,System.Double)">
+            <summary>
+            A sigmoid function. It gives a value between (middle - height/2) and (middle + height/2).
+            </summary>
+            <param name="val">The input value.</param>
+            <param name="center">The center of the sigmoid, where the largest gradient occurs and value is equal to middle.</param>
+            <param name="width">The radius of the sigmoid, outside of which values are near the minimum/maximum.</param>
+            <param name="middle">The middle of the sigmoid output.</param>
+            <param name="height">The height of the sigmoid output. This will be equal to max value - min value.</param>
+        </member>
+        <member name="M:MapsetParser.starrating.taiko.evaluators.ColourEvaluator.EvaluateDifficultyOf(MapsetParser.starrating.taiko.preprocessing.Colour.Data.MonoStreak)">
+            <summary>
+            Evaluate the difficulty of the first note of a <see cref="T:MapsetParser.starrating.taiko.preprocessing.Colour.Data.MonoStreak"/>.
+            </summary>
+        </member>
+        <member name="M:MapsetParser.starrating.taiko.evaluators.ColourEvaluator.EvaluateDifficultyOf(MapsetParser.starrating.taiko.preprocessing.Colour.Data.AlternatingMonoPattern)">
+            <summary>
+            Evaluate the difficulty of the first note of a <see cref="T:MapsetParser.starrating.taiko.preprocessing.Colour.Data.AlternatingMonoPattern"/>.
+            </summary>
+        </member>
+        <member name="M:MapsetParser.starrating.taiko.evaluators.ColourEvaluator.EvaluateDifficultyOf(MapsetParser.starrating.taiko.preprocessing.Colour.Data.RepeatingHitPatterns)">
+            <summary>
+            Evaluate the difficulty of the first note of a <see cref="T:MapsetParser.starrating.taiko.preprocessing.Colour.Data.RepeatingHitPatterns"/>.
+            </summary>
+        </member>
+        <member name="M:MapsetParser.starrating.taiko.evaluators.StaminaEvaluator.speedBonus(System.Double)">
+            <summary>
+            Applies a speed bonus dependent on the time since the last hit performed using this finger.
+            </summary>
+            <param name="interval">The interval between the current and previous note hit using the same finger.</param>
+        </member>
+        <member name="M:MapsetParser.starrating.taiko.evaluators.StaminaEvaluator.availableFingersFor(MapsetParser.starrating.taiko.preprocessing.TaikoDifficultyHitObject)">
+            <summary>
+            Determines the number of fingers available to hit the current <see cref="T:MapsetParser.starrating.taiko.preprocessing.TaikoDifficultyHitObject"/>.
+            Any mono notes that is more than 300ms apart from a colour change will be considered to have more than 2
+            fingers available, since players can hit the same key with multiple fingers.
+            </summary>
+        </member>
+        <member name="M:MapsetParser.starrating.taiko.evaluators.StaminaEvaluator.EvaluateDifficultyOf(MapsetParser.starrating.preprocessing.DifficultyHitObject)">
+            <summary>
+            Evaluates the minimum mechanical stamina required to play the current object. This is calculated using the
+            maximum possible interval between two hits using the same key, by alternating available fingers for each colour.
+            </summary>
+        </member>
+        <member name="T:MapsetParser.starrating.taiko.preprocessing.Colour.Data.AlternatingMonoPattern">
+            <summary>
+            Encodes a list of <see cref="T:MapsetParser.starrating.taiko.preprocessing.Colour.Data.MonoStreak"/>s.
+            <see cref="T:MapsetParser.starrating.taiko.preprocessing.Colour.Data.MonoStreak"/>s with the same <see cref="P:MapsetParser.starrating.taiko.preprocessing.Colour.Data.MonoStreak.RunLength"/> are grouped together.
+            </summary>
+        </member>
+        <member name="F:MapsetParser.starrating.taiko.preprocessing.Colour.Data.AlternatingMonoPattern.MonoStreaks">
+            <summary>
+            <see cref="T:MapsetParser.starrating.taiko.preprocessing.Colour.Data.MonoStreak"/>s that are grouped together within this <see cref="T:MapsetParser.starrating.taiko.preprocessing.Colour.Data.AlternatingMonoPattern"/>.
+            </summary>
+        </member>
+        <member name="F:MapsetParser.starrating.taiko.preprocessing.Colour.Data.AlternatingMonoPattern.Parent">
+            <summary>
+            The parent <see cref="T:MapsetParser.starrating.taiko.preprocessing.Colour.Data.RepeatingHitPatterns"/> that contains this <see cref="T:MapsetParser.starrating.taiko.preprocessing.Colour.Data.AlternatingMonoPattern"/>
+            </summary>
+        </member>
+        <member name="F:MapsetParser.starrating.taiko.preprocessing.Colour.Data.AlternatingMonoPattern.Index">
+            <summary>
+            Index of this <see cref="T:MapsetParser.starrating.taiko.preprocessing.Colour.Data.AlternatingMonoPattern"/> within it's parent <see cref="T:MapsetParser.starrating.taiko.preprocessing.Colour.Data.RepeatingHitPatterns"/>
+            </summary>
+        </member>
+        <member name="P:MapsetParser.starrating.taiko.preprocessing.Colour.Data.AlternatingMonoPattern.FirstHitObject">
+            <summary>
+            The first <see cref="T:MapsetParser.starrating.taiko.preprocessing.TaikoDifficultyHitObject"/> in this <see cref="T:MapsetParser.starrating.taiko.preprocessing.Colour.Data.AlternatingMonoPattern"/>.
+            </summary>
+        </member>
+        <member name="M:MapsetParser.starrating.taiko.preprocessing.Colour.Data.AlternatingMonoPattern.IsRepetitionOf(MapsetParser.starrating.taiko.preprocessing.Colour.Data.AlternatingMonoPattern)">
+            <summary>
+            Determine if this <see cref="T:MapsetParser.starrating.taiko.preprocessing.Colour.Data.AlternatingMonoPattern"/> is a repetition of another <see cref="T:MapsetParser.starrating.taiko.preprocessing.Colour.Data.AlternatingMonoPattern"/>. This
+            is a strict comparison and is true if and only if the colour sequence is exactly the same.
+            </summary>
+        </member>
+        <member name="M:MapsetParser.starrating.taiko.preprocessing.Colour.Data.AlternatingMonoPattern.HasIdenticalMonoLength(MapsetParser.starrating.taiko.preprocessing.Colour.Data.AlternatingMonoPattern)">
+            <summary>
+            Determine if this <see cref="T:MapsetParser.starrating.taiko.preprocessing.Colour.Data.AlternatingMonoPattern"/> has the same mono length of another <see cref="T:MapsetParser.starrating.taiko.preprocessing.Colour.Data.AlternatingMonoPattern"/>.
+            </summary>
+        </member>
+        <member name="T:MapsetParser.starrating.taiko.preprocessing.Colour.Data.MonoStreak">
+            <summary>
+            Encode colour information for a sequence of <see cref="T:MapsetParser.starrating.taiko.preprocessing.TaikoDifficultyHitObject"/>s. Consecutive <see cref="T:MapsetParser.starrating.taiko.preprocessing.TaikoDifficultyHitObject"/>s
+            of the same <see cref="!:Objects.HitType"/> are encoded within the same <see cref="T:MapsetParser.starrating.taiko.preprocessing.Colour.Data.MonoStreak"/>.
+            </summary>
+        </member>
+        <member name="P:MapsetParser.starrating.taiko.preprocessing.Colour.Data.MonoStreak.HitObjects">
+            <summary>
+            List of <see cref="!:DifficultyHitObject"/>s that are encoded within this <see cref="T:MapsetParser.starrating.taiko.preprocessing.Colour.Data.MonoStreak"/>.
+            </summary>
+        </member>
+        <member name="F:MapsetParser.starrating.taiko.preprocessing.Colour.Data.MonoStreak.Parent">
+            <summary>
+            The parent <see cref="T:MapsetParser.starrating.taiko.preprocessing.Colour.Data.AlternatingMonoPattern"/> that contains this <see cref="T:MapsetParser.starrating.taiko.preprocessing.Colour.Data.MonoStreak"/>
+            </summary>
+        </member>
+        <member name="F:MapsetParser.starrating.taiko.preprocessing.Colour.Data.MonoStreak.Index">
+            <summary>
+            Index of this <see cref="T:MapsetParser.starrating.taiko.preprocessing.Colour.Data.MonoStreak"/> within it's parent <see cref="T:MapsetParser.starrating.taiko.preprocessing.Colour.Data.AlternatingMonoPattern"/>
+            </summary>
+        </member>
+        <member name="P:MapsetParser.starrating.taiko.preprocessing.Colour.Data.MonoStreak.FirstHitObject">
+            <summary>
+            The first <see cref="T:MapsetParser.starrating.taiko.preprocessing.TaikoDifficultyHitObject"/> in this <see cref="T:MapsetParser.starrating.taiko.preprocessing.Colour.Data.MonoStreak"/>.
+            </summary>
+        </member>
+        <member name="P:MapsetParser.starrating.taiko.preprocessing.Colour.Data.MonoStreak.LastHitObject">
+            <summary>
+            The last <see cref="T:MapsetParser.starrating.taiko.preprocessing.TaikoDifficultyHitObject"/> in this <see cref="T:MapsetParser.starrating.taiko.preprocessing.Colour.Data.MonoStreak"/>.
+            </summary>
+        </member>
+        <member name="P:MapsetParser.starrating.taiko.preprocessing.Colour.Data.MonoStreak.HitType">
+            <summary>
+            The hit type of all objects encoded within this <see cref="T:MapsetParser.starrating.taiko.preprocessing.Colour.Data.MonoStreak"/>
+            </summary>
+        </member>
+        <member name="P:MapsetParser.starrating.taiko.preprocessing.Colour.Data.MonoStreak.RunLength">
+            <summary>
+            How long the mono pattern encoded within is
+            </summary>
+        </member>
+        <member name="T:MapsetParser.starrating.taiko.preprocessing.Colour.Data.RepeatingHitPatterns">
+            <summary>
+            Encodes a list of <see cref="T:MapsetParser.starrating.taiko.preprocessing.Colour.Data.AlternatingMonoPattern"/>s, grouped together by back and forth repetition of the same
+            <see cref="T:MapsetParser.starrating.taiko.preprocessing.Colour.Data.AlternatingMonoPattern"/>. Also stores the repetition interval between this and the previous <see cref="T:MapsetParser.starrating.taiko.preprocessing.Colour.Data.RepeatingHitPatterns"/>.
+            </summary>
+        </member>
+        <member name="F:MapsetParser.starrating.taiko.preprocessing.Colour.Data.RepeatingHitPatterns.max_repetition_interval">
+            <summary>
+            Maximum amount of <see cref="T:MapsetParser.starrating.taiko.preprocessing.Colour.Data.RepeatingHitPatterns"/>s to look back to find a repetition.
+            </summary>
+        </member>
+        <member name="F:MapsetParser.starrating.taiko.preprocessing.Colour.Data.RepeatingHitPatterns.AlternatingMonoPatterns">
+            <summary>
+            The <see cref="T:MapsetParser.starrating.taiko.preprocessing.Colour.Data.AlternatingMonoPattern"/>s that are grouped together within this <see cref="T:MapsetParser.starrating.taiko.preprocessing.Colour.Data.RepeatingHitPatterns"/>.
+            </summary>
+        </member>
+        <member name="P:MapsetParser.starrating.taiko.preprocessing.Colour.Data.RepeatingHitPatterns.FirstHitObject">
+            <summary>
+            The first <see cref="T:MapsetParser.starrating.taiko.preprocessing.TaikoDifficultyHitObject"/> in this <see cref="T:MapsetParser.starrating.taiko.preprocessing.Colour.Data.RepeatingHitPatterns"/>
+            </summary>
+        </member>
+        <member name="F:MapsetParser.starrating.taiko.preprocessing.Colour.Data.RepeatingHitPatterns.Previous">
+            <summary>
+            The previous <see cref="T:MapsetParser.starrating.taiko.preprocessing.Colour.Data.RepeatingHitPatterns"/>. This is used to determine the repetition interval.
+            </summary>
+        </member>
+        <member name="P:MapsetParser.starrating.taiko.preprocessing.Colour.Data.RepeatingHitPatterns.RepetitionInterval">
+            <summary>
+            How many <see cref="T:MapsetParser.starrating.taiko.preprocessing.Colour.Data.RepeatingHitPatterns"/> between the current and previous identical <see cref="T:MapsetParser.starrating.taiko.preprocessing.Colour.Data.RepeatingHitPatterns"/>.
+            If no repetition is found this will have a value of <see cref="F:MapsetParser.starrating.taiko.preprocessing.Colour.Data.RepeatingHitPatterns.max_repetition_interval"/> + 1.
+            </summary>
+        </member>
+        <member name="M:MapsetParser.starrating.taiko.preprocessing.Colour.Data.RepeatingHitPatterns.isRepetitionOf(MapsetParser.starrating.taiko.preprocessing.Colour.Data.RepeatingHitPatterns)">
+            <summary>
+            Returns true if other is considered a repetition of this pattern. This is true if other's first two payloads
+            have identical mono lengths.
+            </summary>
+        </member>
+        <member name="M:MapsetParser.starrating.taiko.preprocessing.Colour.Data.RepeatingHitPatterns.FindRepetitionInterval">
+            <summary>
+            Finds the closest previous <see cref="T:MapsetParser.starrating.taiko.preprocessing.Colour.Data.RepeatingHitPatterns"/> that has the identical <see cref="F:MapsetParser.starrating.taiko.preprocessing.Colour.Data.RepeatingHitPatterns.AlternatingMonoPatterns"/>.
+            Interval is defined as the amount of <see cref="T:MapsetParser.starrating.taiko.preprocessing.Colour.Data.RepeatingHitPatterns"/> chunks between the current and repeated patterns.
+            </summary>
+        </member>
+        <member name="T:MapsetParser.starrating.taiko.preprocessing.Colour.TaikoColourDifficultyPreprocessor">
+            <summary>
+            Utility class to perform various encodings.
+            </summary>
+        </member>
+        <member name="M:MapsetParser.starrating.taiko.preprocessing.Colour.TaikoColourDifficultyPreprocessor.ProcessAndAssign(System.Collections.Generic.List{MapsetParser.starrating.preprocessing.DifficultyHitObject})">
+            <summary>
+            Processes and encodes a list of <see cref="T:MapsetParser.starrating.taiko.preprocessing.TaikoDifficultyHitObject"/>s into a list of <see cref="T:MapsetParser.starrating.taiko.preprocessing.Colour.TaikoDifficultyHitObjectColour"/>s,
+            assigning the appropriate <see cref="T:MapsetParser.starrating.taiko.preprocessing.Colour.TaikoDifficultyHitObjectColour"/>s to each <see cref="T:MapsetParser.starrating.taiko.preprocessing.TaikoDifficultyHitObject"/>.
+            </summary>
+        </member>
+        <member name="M:MapsetParser.starrating.taiko.preprocessing.Colour.TaikoColourDifficultyPreprocessor.encode(System.Collections.Generic.List{MapsetParser.starrating.preprocessing.DifficultyHitObject})">
+            <summary>
+            Encodes a list of <see cref="T:MapsetParser.starrating.taiko.preprocessing.TaikoDifficultyHitObject"/>s into a list of <see cref="T:MapsetParser.starrating.taiko.preprocessing.Colour.Data.RepeatingHitPatterns"/>s.
+            </summary>
+        </member>
+        <member name="M:MapsetParser.starrating.taiko.preprocessing.Colour.TaikoColourDifficultyPreprocessor.encodeMonoStreak(System.Collections.Generic.List{MapsetParser.starrating.preprocessing.DifficultyHitObject})">
+            <summary>
+            Encodes a list of <see cref="T:MapsetParser.starrating.taiko.preprocessing.TaikoDifficultyHitObject"/>s into a list of <see cref="T:MapsetParser.starrating.taiko.preprocessing.Colour.Data.MonoStreak"/>s.
+            </summary>
+        </member>
+        <member name="M:MapsetParser.starrating.taiko.preprocessing.Colour.TaikoColourDifficultyPreprocessor.encodeAlternatingMonoPattern(System.Collections.Generic.List{MapsetParser.starrating.taiko.preprocessing.Colour.Data.MonoStreak})">
+            <summary>
+            Encodes a list of <see cref="T:MapsetParser.starrating.taiko.preprocessing.Colour.Data.MonoStreak"/>s into a list of <see cref="T:MapsetParser.starrating.taiko.preprocessing.Colour.Data.AlternatingMonoPattern"/>s.
+            </summary>
+        </member>
+        <member name="M:MapsetParser.starrating.taiko.preprocessing.Colour.TaikoColourDifficultyPreprocessor.encodeRepeatingHitPattern(System.Collections.Generic.List{MapsetParser.starrating.taiko.preprocessing.Colour.Data.AlternatingMonoPattern})">
+            <summary>
+            Encodes a list of <see cref="T:MapsetParser.starrating.taiko.preprocessing.Colour.Data.AlternatingMonoPattern"/>s into a list of <see cref="T:MapsetParser.starrating.taiko.preprocessing.Colour.Data.RepeatingHitPatterns"/>s.
+            </summary>
+        </member>
+        <member name="T:MapsetParser.starrating.taiko.preprocessing.Colour.TaikoDifficultyHitObjectColour">
+            <summary>
+            Stores colour compression information for a <see cref="T:MapsetParser.starrating.taiko.preprocessing.TaikoDifficultyHitObject"/>.
+            </summary>
+        </member>
+        <member name="F:MapsetParser.starrating.taiko.preprocessing.Colour.TaikoDifficultyHitObjectColour.MonoStreak">
+            <summary>
+            The <see cref="F:MapsetParser.starrating.taiko.preprocessing.Colour.TaikoDifficultyHitObjectColour.MonoStreak"/> that encodes this note.
+            </summary>
+        </member>
+        <member name="F:MapsetParser.starrating.taiko.preprocessing.Colour.TaikoDifficultyHitObjectColour.AlternatingMonoPattern">
+            <summary>
+            The <see cref="F:MapsetParser.starrating.taiko.preprocessing.Colour.TaikoDifficultyHitObjectColour.AlternatingMonoPattern"/> that encodes this note.
+            </summary>
+        </member>
+        <member name="F:MapsetParser.starrating.taiko.preprocessing.Colour.TaikoDifficultyHitObjectColour.RepeatingHitPattern">
+            <summary>
+            The <see cref="F:MapsetParser.starrating.taiko.preprocessing.Colour.TaikoDifficultyHitObjectColour.RepeatingHitPattern"/> that encodes this note.
+            </summary>
+        </member>
+        <member name="P:MapsetParser.starrating.taiko.preprocessing.Colour.TaikoDifficultyHitObjectColour.PreviousColourChange">
+            <summary>
+            The closest past <see cref="T:MapsetParser.starrating.taiko.preprocessing.TaikoDifficultyHitObject"/> that's not the same colour.
+            </summary>
+        </member>
+        <member name="P:MapsetParser.starrating.taiko.preprocessing.Colour.TaikoDifficultyHitObjectColour.NextColourChange">
+            <summary>
+            The closest future <see cref="T:MapsetParser.starrating.taiko.preprocessing.TaikoDifficultyHitObject"/> that's not the same colour.
+            </summary>
+        </member>
+        <member name="T:MapsetParser.starrating.taiko.preprocessing.Rhythm.TaikoDifficultyHitObjectRhythm">
+            <summary>
+            Represents a rhythm change in a taiko map.
+            </summary>
+        </member>
+        <member name="F:MapsetParser.starrating.taiko.preprocessing.Rhythm.TaikoDifficultyHitObjectRhythm.Difficulty">
+            <summary>
+            The difficulty multiplier associated with this rhythm change.
+            </summary>
+        </member>
+        <member name="F:MapsetParser.starrating.taiko.preprocessing.Rhythm.TaikoDifficultyHitObjectRhythm.Ratio">
+            <summary>
+            The ratio of current <see cref="!:osu.Game.Rulesets.Difficulty.Preprocessing.DifficultyHitObject.DeltaTime"/>
+            to previous <see cref="!:osu.Game.Rulesets.Difficulty.Preprocessing.DifficultyHitObject.DeltaTime"/> for the rhythm change.
+            A <see cref="F:MapsetParser.starrating.taiko.preprocessing.Rhythm.TaikoDifficultyHitObjectRhythm.Ratio"/> above 1 indicates a slow-down; a <see cref="F:MapsetParser.starrating.taiko.preprocessing.Rhythm.TaikoDifficultyHitObjectRhythm.Ratio"/> below 1 indicates a speed-up.
+            </summary>
+        </member>
+        <member name="M:MapsetParser.starrating.taiko.preprocessing.Rhythm.TaikoDifficultyHitObjectRhythm.#ctor(System.Int32,System.Int32,System.Double)">
+            <summary>
+            Creates an object representing a rhythm change.
+            </summary>
+            <param name="numerator">The numerator for <see cref="F:MapsetParser.starrating.taiko.preprocessing.Rhythm.TaikoDifficultyHitObjectRhythm.Ratio"/>.</param>
+            <param name="denominator">The denominator for <see cref="F:MapsetParser.starrating.taiko.preprocessing.Rhythm.TaikoDifficultyHitObjectRhythm.Ratio"/></param>
+            <param name="difficulty">The difficulty multiplier associated with this rhythm change.</param>
+        </member>
+        <member name="T:MapsetParser.starrating.taiko.preprocessing.TaikoDifficultyHitObject">
+            <summary>
+            Represents a single hit object in taiko difficulty calculation.
+            </summary>
+        </member>
+        <member name="F:MapsetParser.starrating.taiko.preprocessing.TaikoDifficultyHitObject.monoDifficultyHitObjects">
+            <summary>
+            The list of all <see cref="T:MapsetParser.starrating.taiko.preprocessing.TaikoDifficultyHitObject"/> of the same colour as this <see cref="T:MapsetParser.starrating.taiko.preprocessing.TaikoDifficultyHitObject"/> in the beatmap.
+            </summary>
+        </member>
+        <member name="F:MapsetParser.starrating.taiko.preprocessing.TaikoDifficultyHitObject.MonoIndex">
+            <summary>
+            The index of this <see cref="T:MapsetParser.starrating.taiko.preprocessing.TaikoDifficultyHitObject"/> in <see cref="F:MapsetParser.starrating.taiko.preprocessing.TaikoDifficultyHitObject.monoDifficultyHitObjects"/>.
+            </summary>
+        </member>
+        <member name="F:MapsetParser.starrating.taiko.preprocessing.TaikoDifficultyHitObject.noteDifficultyHitObjects">
+            <summary>
+            The list of all <see cref="T:MapsetParser.starrating.taiko.preprocessing.TaikoDifficultyHitObject"/> that is either a regular note or finisher in the beatmap
+            </summary>
+        </member>
+        <member name="F:MapsetParser.starrating.taiko.preprocessing.TaikoDifficultyHitObject.NoteIndex">
+            <summary>
+            The index of this <see cref="T:MapsetParser.starrating.taiko.preprocessing.TaikoDifficultyHitObject"/> in <see cref="F:MapsetParser.starrating.taiko.preprocessing.TaikoDifficultyHitObject.noteDifficultyHitObjects"/>.
+            </summary>
+        </member>
+        <member name="F:MapsetParser.starrating.taiko.preprocessing.TaikoDifficultyHitObject.Rhythm">
+            <summary>
+            The rhythm required to hit this hit object.
+            </summary>
+        </member>
+        <member name="F:MapsetParser.starrating.taiko.preprocessing.TaikoDifficultyHitObject.Colour">
+            <summary>
+            Colour data for this hit object. This is used by colour evaluator to calculate colour difficulty, but can be used
+            by other skills in the future.
+            </summary>
+        </member>
+        <member name="M:MapsetParser.starrating.taiko.preprocessing.TaikoDifficultyHitObject.#ctor(MapsetParser.objects.HitObject,MapsetParser.objects.HitObject,MapsetParser.objects.HitObject,System.Collections.Generic.List{MapsetParser.starrating.preprocessing.DifficultyHitObject},System.Collections.Generic.List{MapsetParser.starrating.taiko.preprocessing.TaikoDifficultyHitObject},System.Collections.Generic.List{MapsetParser.starrating.taiko.preprocessing.TaikoDifficultyHitObject},System.Collections.Generic.List{MapsetParser.starrating.taiko.preprocessing.TaikoDifficultyHitObject},System.Int32)">
+            <summary>
+            Creates a new difficulty hit object.
+            </summary>
+            <param name="hitObject">The gameplay <see cref="T:MapsetParser.objects.HitObject"/> associated with this difficulty object.</param>
+            <param name="lastObject">The gameplay <see cref="T:MapsetParser.objects.HitObject"/> preceding <paramref name="hitObject"/>.</param>
+            <param name="lastLastObject">The gameplay <see cref="T:MapsetParser.objects.HitObject"/> preceding <paramref name="lastObject"/>.</param>
+            <param name="objects">The list of all <see cref="T:MapsetParser.starrating.preprocessing.DifficultyHitObject"/>s in the current beatmap.</param>
+            <param name="centreHitObjects">The list of centre (don) <see cref="T:MapsetParser.starrating.preprocessing.DifficultyHitObject"/>s in the current beatmap.</param>
+            <param name="rimHitObjects">The list of rim (kat) <see cref="T:MapsetParser.starrating.preprocessing.DifficultyHitObject"/>s in the current beatmap.</param>
+            <param name="noteObjects">The list of <see cref="T:MapsetParser.starrating.preprocessing.DifficultyHitObject"/>s that is a hit (i.e. not a drumroll or swell) in the current beatmap.</param>
+            <param name="index">The position of this <see cref="T:MapsetParser.starrating.preprocessing.DifficultyHitObject"/> in the <paramref name="objects"/> list.</param>
+        </member>
+        <member name="F:MapsetParser.starrating.taiko.preprocessing.TaikoDifficultyHitObject.common_rhythms">
+            <summary>
+            List of most common rhythm changes in taiko maps.
+            </summary>
+            <remarks>
+            The general guidelines for the values are:
+            <list type="bullet">
+            <item>rhythm changes with ratio closer to 1 (that are <i>not</i> 1) are harder to play,</item>
+            <item>speeding up is <i>generally</i> harder than slowing down (with exceptions of rhythm changes requiring a hand switch).</item>
+            </list>
+            </remarks>
+        </member>
+        <member name="M:MapsetParser.starrating.taiko.preprocessing.TaikoDifficultyHitObject.getClosestRhythm(MapsetParser.objects.HitObject,MapsetParser.objects.HitObject)">
+            <summary>
+            Returns the closest rhythm change from <see cref="F:MapsetParser.starrating.taiko.preprocessing.TaikoDifficultyHitObject.common_rhythms"/> required to hit this object.
+            </summary>
+            <param name="lastObject">The gameplay <see cref="T:MapsetParser.objects.HitObject"/> preceding this one.</param>
+            <param name="lastLastObject">The gameplay <see cref="T:MapsetParser.objects.HitObject"/> preceding <paramref name="lastObject"/>.</param>
+        </member>
+        <member name="T:MapsetParser.starrating.taiko.skills.Colour">
+            <summary>
+            Calculates the colour coefficient of taiko difficulty.
+            </summary>
+        </member>
+        <member name="M:MapsetParser.starrating.taiko.skills.Peaks.norm(System.Double,System.Double[])">
+            <summary>
+            Returns the <i>p</i>-norm of an <i>n</i>-dimensional vector.
+            </summary>
+            <param name="p">The value of <i>p</i> to calculate the norm for.</param>
+            <param name="values">The coefficients of the vector.</param>
+        </member>
+        <member name="M:MapsetParser.starrating.taiko.skills.Peaks.DifficultyValue">
+            <summary>
+            Returns the combined star rating of the beatmap, calculated using peak strains from all sections of the map.
+            </summary>
+            <remarks>
+            For each section, the peak strains of all separate skills are combined into a single peak strain for the section.
+            The resulting partial rating of the beatmap is a weighted sum of the combined peaks (higher peaks are weighted more).
+            </remarks>
+        </member>
+        <member name="T:MapsetParser.starrating.taiko.skills.Rhythm">
+            <summary>
+            Calculates the rhythm coefficient of taiko difficulty.
+            </summary>
+        </member>
+        <member name="F:MapsetParser.starrating.taiko.skills.Rhythm.strain_decay">
+            <summary>
+            The note-based decay for rhythm strain.
+            </summary>
+            <remarks>
+            <see cref="P:MapsetParser.starrating.taiko.skills.Rhythm.StrainDecayBase"/> is not used here, as it's time- and not note-based.
+            </remarks>
+        </member>
+        <member name="F:MapsetParser.starrating.taiko.skills.Rhythm.rhythm_history_max_length">
+            <summary>
+            Maximum number of entries in <see cref="F:MapsetParser.starrating.taiko.skills.Rhythm.rhythmHistory"/>.
+            </summary>
+        </member>
+        <member name="F:MapsetParser.starrating.taiko.skills.Rhythm.rhythmHistory">
+            <summary>
+            Contains the last <see cref="F:MapsetParser.starrating.taiko.skills.Rhythm.rhythm_history_max_length"/> changes in note sequence rhythms.
+            </summary>
+        </member>
+        <member name="F:MapsetParser.starrating.taiko.skills.Rhythm.currentStrain">
+            <summary>
+            Contains the rolling rhythm strain.
+            Used to apply per-note decay.
+            </summary>
+        </member>
+        <member name="F:MapsetParser.starrating.taiko.skills.Rhythm.notesSinceRhythmChange">
+            <summary>
+            Number of notes since the last rhythm change has taken place.
+            </summary>
+        </member>
+        <member name="M:MapsetParser.starrating.taiko.skills.Rhythm.repetitionPenalties(MapsetParser.starrating.taiko.preprocessing.TaikoDifficultyHitObject)">
+            <summary>
+            Returns a penalty to apply to the current hit object caused by repeating rhythm changes.
+            </summary>
+            <remarks>
+            Repetitions of more recent patterns are associated with a higher penalty.
+            </remarks>
+            <param name="hitObject">The current hit object being considered.</param>
+        </member>
+        <member name="M:MapsetParser.starrating.taiko.skills.Rhythm.samePattern(System.Int32,System.Int32)">
+            <summary>
+            Determines whether the rhythm change pattern starting at <paramref name="start"/> is a repeat of any of the
+            <paramref name="mostRecentPatternsToCompare"/>.
+            </summary>
+        </member>
+        <member name="M:MapsetParser.starrating.taiko.skills.Rhythm.repetitionPenalty(System.Int32)">
+            <summary>
+            Calculates a single rhythm repetition penalty.
+            </summary>
+            <param name="notesSince">Number of notes since the last repetition of a rhythm change.</param>
+        </member>
+        <member name="M:MapsetParser.starrating.taiko.skills.Rhythm.patternLengthPenalty(System.Int32)">
+            <summary>
+            Calculates a penalty based on the number of notes since the last rhythm change.
+            Both rare and frequent rhythm changes are penalised.
+            </summary>
+            <param name="patternLength">Number of notes since the last rhythm change.</param>
+        </member>
+        <member name="M:MapsetParser.starrating.taiko.skills.Rhythm.speedPenalty(System.Double)">
+            <summary>
+            Calculates a penalty for objects that do not require alternating hands.
+            </summary>
+            <param name="deltaTime">Time (in milliseconds) since the last hit object.</param>
+        </member>
+        <member name="M:MapsetParser.starrating.taiko.skills.Rhythm.resetRhythmAndStrain">
+            <summary>
+            Resets the rolling strain value and <see cref="F:MapsetParser.starrating.taiko.skills.Rhythm.notesSinceRhythmChange"/> counter.
+            </summary>
+        </member>
+        <member name="T:MapsetParser.starrating.taiko.skills.Stamina">
+            <summary>
+            Calculates the stamina coefficient of taiko difficulty.
+            </summary>
+        </member>
+        <member name="M:MapsetParser.starrating.taiko.skills.Stamina.#ctor">
+            <summary>
+            Creates a <see cref="T:MapsetParser.starrating.taiko.skills.Stamina"/> skill.
+            </summary>
+            <param name="mods">Mods for use in skill calculations.</param>
+        </member>
+        <member name="F:MapsetParser.starrating.taiko.TaikoDifficultyAttributes.StaminaDifficulty">
+            <summary>
+            The difficulty corresponding to the stamina skill.
+            </summary>
+        </member>
+        <member name="F:MapsetParser.starrating.taiko.TaikoDifficultyAttributes.RhythmDifficulty">
+            <summary>
+            The difficulty corresponding to the rhythm skill.
+            </summary>
+        </member>
+        <member name="F:MapsetParser.starrating.taiko.TaikoDifficultyAttributes.ColourDifficulty">
+            <summary>
+            The difficulty corresponding to the colour skill.
+            </summary>
+        </member>
+        <member name="F:MapsetParser.starrating.taiko.TaikoDifficultyAttributes.PeakDifficulty">
+            <summary>
+            The difficulty corresponding to the hardest parts of the map.
+            </summary>
+        </member>
+        <member name="F:MapsetParser.starrating.taiko.TaikoDifficultyAttributes.GreatHitWindow">
+            <summary>
+            The perceived hit window for a GREAT hit inclusive of rate-adjusting mods (DT/HT/etc).
+            </summary>
+        </member>
+        <member name="M:MapsetParser.starrating.taiko.TaikoDifficultyCalculator.rescale(System.Double)">
+            <summary>
+            Applies a final re-scaling of the star rating.
+            </summary>
+            <param name="sr">The raw star rating value before re-scaling.</param>
+        </member>
+        <member name="T:MapsetParser.starrating.utils.LimitedCapacityQueue`1">
+            <summary>
+            An indexed queue with limited capacity.
+            Respects first-in-first-out insertion order.
+            </summary>
+        </member>
+        <member name="P:MapsetParser.starrating.utils.LimitedCapacityQueue`1.Count">
+            <summary>
+            The number of elements in the queue.
+            </summary>
+        </member>
+        <member name="P:MapsetParser.starrating.utils.LimitedCapacityQueue`1.Full">
+            <summary>
+            Whether the queue is full (adding any new items will cause removing existing ones).
+            </summary>
+        </member>
+        <member name="M:MapsetParser.starrating.utils.LimitedCapacityQueue`1.#ctor(System.Int32)">
+            <summary>
+            Constructs a new <see cref="T:MapsetParser.starrating.utils.LimitedCapacityQueue`1"/>
+            </summary>
+            <param name="capacity">The number of items the queue can hold.</param>
+        </member>
+        <member name="M:MapsetParser.starrating.utils.LimitedCapacityQueue`1.Clear">
+            <summary>
+            Removes all elements from the <see cref="T:MapsetParser.starrating.utils.LimitedCapacityQueue`1"/>.
+            </summary>
+        </member>
+        <member name="M:MapsetParser.starrating.utils.LimitedCapacityQueue`1.Dequeue">
+            <summary>
+            Removes an item from the front of the <see cref="T:MapsetParser.starrating.utils.LimitedCapacityQueue`1"/>.
+            </summary>
+            <returns>The item removed from the front of the queue.</returns>
+        </member>
+        <member name="M:MapsetParser.starrating.utils.LimitedCapacityQueue`1.Enqueue(`0)">
+            <summary>
+            Adds an item to the back of the <see cref="T:MapsetParser.starrating.utils.LimitedCapacityQueue`1"/>.
+            If the queue is holding <see cref="P:MapsetParser.starrating.utils.LimitedCapacityQueue`1.Count"/> elements at the point of addition,
+            the item at the front of the queue will be removed.
+            </summary>
+            <param name="item">The item to be added to the back of the queue.</param>
+        </member>
+        <member name="P:MapsetParser.starrating.utils.LimitedCapacityQueue`1.Item(System.Int32)">
+            <summary>
+            Retrieves the item at the given index in the queue.
+            </summary>
+            <param name="index">
+            The index of the item to retrieve.
+            The item with index 0 is at the front of the queue
+            (it was added the earliest).
+            </param>
+        </member>
+        <member name="M:MapsetParser.starrating.utils.LimitedCapacityQueue`1.GetEnumerator">
+            <summary>
+            Enumerates the queue from its start to its end.
             </summary>
         </member>
         <member name="T:MapsetParser.starrating.utils.LimitedCapacityStack`1">

--- a/objects/taiko/Hit.cs
+++ b/objects/taiko/Hit.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace MapsetParser.objects.taiko
+{
+    public class Hit : HitObject
+    {
+        public Hit(string[] args, Beatmap beatmap) : base(args, beatmap)
+        {
+            Type = GetType();
+        }
+
+        /// <summary>
+        /// The <see cref="HitType"/> that actuates this <see cref="Hit"/>.
+        /// </summary>
+        public HitType Type;
+
+        private HitType GetType()
+        {
+            switch (hitSound)
+            {
+                case HitSound.Whistle:
+                    return HitType.Rim;
+                case HitSound.Clap:
+                    return HitType.Rim;
+                default:
+                    return HitType.Centre;
+            }
+        }
+    }
+}

--- a/objects/taiko/HitType.cs
+++ b/objects/taiko/HitType.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace MapsetParser.objects.taiko
+{
+    /// <summary>
+    /// The type of a <see cref="Hit"/>.
+    /// </summary>
+    public enum HitType
+    {
+        /// <summary>
+        /// A <see cref="Hit"/> that can be hit by the centre portion of the drum.
+        /// </summary>
+        Centre,
+
+        /// <summary>
+        /// A <see cref="Hit"/> that can be hit by the rim portion of the drum.
+        /// </summary>
+        Rim
+    }
+}

--- a/scoring/HitResult.cs
+++ b/scoring/HitResult.cs
@@ -1,0 +1,129 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.ComponentModel;
+using System.Runtime.Serialization;
+
+namespace MapsetParser.scoring
+{
+    public enum HitResult
+    {
+        /// <summary>
+        /// Indicates that the object has not been judged yet.
+        /// </summary>
+        [Description(@"")]
+        [EnumMember(Value = "none")]
+        None,
+
+        /// <summary>
+        /// Indicates that the object has been judged as a miss.
+        /// </summary>
+        /// <remarks>
+        /// This miss window should determine how early a hit can be before it is considered for judgement (as opposed to being ignored as
+        /// "too far in the future). It should also define when a forced miss should be triggered (as a result of no user input in time).
+        /// </remarks>
+        [Description(@"Miss")]
+        [EnumMember(Value = "miss")]
+        Miss,
+
+        [Description(@"Meh")]
+        [EnumMember(Value = "meh")]
+        Meh,
+
+        [Description(@"OK")]
+        [EnumMember(Value = "ok")]
+        Ok,
+
+        [Description(@"Good")]
+        [EnumMember(Value = "good")]
+        Good,
+
+        [Description(@"Great")]
+        [EnumMember(Value = "great")]
+        Great,
+
+        /// <summary>
+        /// This is an optional timing window tighter than <see cref="Great"/>.
+        /// </summary>
+        /// <remarks>
+        /// By default, this does not give any bonus accuracy or score.
+        /// To have it affect scoring, consider adding a nested bonus object.
+        /// </remarks>
+        [Description(@"Perfect")]
+        [EnumMember(Value = "perfect")]
+        Perfect,
+
+        /// <summary>
+        /// Indicates small tick miss.
+        /// </summary>
+        [EnumMember(Value = "small_tick_miss")]
+        SmallTickMiss,
+
+        /// <summary>
+        /// Indicates a small tick hit.
+        /// </summary>
+        [Description(@"S Tick")]
+        [EnumMember(Value = "small_tick_hit")]
+        SmallTickHit,
+
+        /// <summary>
+        /// Indicates a large tick miss.
+        /// </summary>
+        [EnumMember(Value = "large_tick_miss")]
+        LargeTickMiss,
+
+        /// <summary>
+        /// Indicates a large tick hit.
+        /// </summary>
+        [Description(@"L Tick")]
+        [EnumMember(Value = "large_tick_hit")]
+        LargeTickHit,
+
+        /// <summary>
+        /// Indicates a small bonus.
+        /// </summary>
+        [Description("S Bonus")]
+        [EnumMember(Value = "small_bonus")]
+        SmallBonus,
+
+        /// <summary>
+        /// Indicates a large bonus.
+        /// </summary>
+        [Description("L Bonus")]
+        [EnumMember(Value = "large_bonus")]
+        LargeBonus,
+
+        /// <summary>
+        /// Indicates a miss that should be ignored for scoring purposes.
+        /// </summary>
+        [EnumMember(Value = "ignore_miss")]
+        IgnoreMiss,
+
+        /// <summary>
+        /// Indicates a hit that should be ignored for scoring purposes.
+        /// </summary>
+        [EnumMember(Value = "ignore_hit")]
+        IgnoreHit,
+
+        /// <summary>
+        /// Indicates that a combo break should occur, but does not otherwise affect score.
+        /// </summary>
+        /// <remarks>
+        /// May be paired with <see cref="IgnoreHit"/>.
+        /// </remarks>
+        [EnumMember(Value = "combo_break")]
+        ComboBreak,
+
+        /// <summary>
+        /// A special result used as a padding value for legacy rulesets. It is a hit type and affects combo, but does not affect the base score (does not affect accuracy).
+        /// </summary>
+        /// <remarks>
+        /// DO NOT USE.
+        /// </remarks>
+        [EnumMember(Value = "legacy_combo_increase")]
+
+        [Obsolete("Do not use.")]
+        LegacyComboIncrease = 99
+    }
+}

--- a/scoring/HitWindows.cs
+++ b/scoring/HitWindows.cs
@@ -1,0 +1,221 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using MapsetParser.starrating;
+
+namespace MapsetParser.scoring
+{
+    /// <summary>
+    /// A structure containing timing data for hit window based gameplay.
+    /// </summary>
+    public class HitWindows
+    {
+        private static readonly DifficultyRange[] base_ranges =
+        {
+            new DifficultyRange(HitResult.Perfect, 22.4D, 19.4D, 13.9D),
+            new DifficultyRange(HitResult.Great, 64, 49, 34),
+            new DifficultyRange(HitResult.Good, 97, 82, 67),
+            new DifficultyRange(HitResult.Ok, 127, 112, 97),
+            new DifficultyRange(HitResult.Meh, 151, 136, 121),
+            new DifficultyRange(HitResult.Miss, 188, 173, 158),
+        };
+
+        private double perfect;
+        private double great;
+        private double good;
+        private double ok;
+        private double meh;
+        private double miss;
+
+        /// <summary>
+        /// An empty <see cref="HitWindows"/> with only <see cref="HitResult.Miss"/> and <see cref="HitResult.Perfect"/>.
+        /// No time values are provided (meaning instantaneous hit or miss).
+        /// </summary>
+        public static HitWindows Empty => new EmptyHitWindows();
+
+        public HitWindows()
+        {
+        }
+
+        /// <summary>
+        /// Retrieves the <see cref="HitResult"/> with the largest hit window that produces a successful hit.
+        /// </summary>
+        /// <returns>The lowest allowed successful <see cref="HitResult"/>.</returns>
+        protected HitResult LowestSuccessfulHitResult()
+        {
+            for (var result = HitResult.Meh; result <= HitResult.Perfect; ++result)
+            {
+                if (IsHitResultAllowed(result))
+                    return result;
+            }
+
+            return HitResult.None;
+        }
+
+        /// <summary>
+        /// Retrieves a mapping of <see cref="HitResult"/>s to their timing windows for all allowed <see cref="HitResult"/>s.
+        /// </summary>
+        public IEnumerable<(HitResult result, double length)> GetAllAvailableWindows()
+        {
+            for (var result = HitResult.Meh; result <= HitResult.Perfect; ++result)
+            {
+                if (IsHitResultAllowed(result))
+                    yield return (result, WindowFor(result));
+            }
+        }
+
+        /// <summary>
+        /// Check whether it is possible to achieve the provided <see cref="HitResult"/>.
+        /// </summary>
+        /// <param name="result">The result type to check.</param>
+        /// <returns>Whether the <see cref="HitResult"/> can be achieved.</returns>
+        public virtual bool IsHitResultAllowed(HitResult result) => true;
+
+        /// <summary>
+        /// Sets hit windows with values that correspond to a difficulty parameter.
+        /// </summary>
+        /// <param name="difficulty">The parameter.</param>
+        public void SetDifficulty(double difficulty)
+        {
+            foreach (var range in GetRanges())
+            {
+                double value = IBeatmapDifficultyInfo.DifficultyRange(difficulty, (range.Min, range.Average, range.Max));
+
+                switch (range.Result)
+                {
+                    case HitResult.Miss:
+                        miss = value;
+                        break;
+
+                    case HitResult.Meh:
+                        meh = value;
+                        break;
+
+                    case HitResult.Ok:
+                        ok = value;
+                        break;
+
+                    case HitResult.Good:
+                        good = value;
+                        break;
+
+                    case HitResult.Great:
+                        great = value;
+                        break;
+
+                    case HitResult.Perfect:
+                        perfect = value;
+                        break;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Retrieves the <see cref="HitResult"/> for a time offset.
+        /// </summary>
+        /// <param name="timeOffset">The time offset.</param>
+        /// <returns>The hit result, or <see cref="HitResult.None"/> if <paramref name="timeOffset"/> doesn't result in a judgement.</returns>
+        public HitResult ResultFor(double timeOffset)
+        {
+            timeOffset = Math.Abs(timeOffset);
+
+            for (var result = HitResult.Perfect; result >= HitResult.Miss; --result)
+            {
+                if (IsHitResultAllowed(result) && timeOffset <= WindowFor(result))
+                    return result;
+            }
+
+            return HitResult.None;
+        }
+
+        /// <summary>
+        /// Retrieves the hit window for a <see cref="HitResult"/>.
+        /// This is the number of +/- milliseconds allowed for the requested result (so the actual hittable range is double this).
+        /// </summary>
+        /// <param name="result">The expected <see cref="HitResult"/>.</param>
+        /// <returns>One half of the hit window for <paramref name="result"/>.</returns>
+        public double WindowFor(HitResult result)
+        {
+            switch (result)
+            {
+                case HitResult.Perfect:
+                    return perfect;
+
+                case HitResult.Great:
+                    return great;
+
+                case HitResult.Good:
+                    return good;
+
+                case HitResult.Ok:
+                    return ok;
+
+                case HitResult.Meh:
+                    return meh;
+
+                case HitResult.Miss:
+                    return miss;
+
+                default:
+                    throw new ArgumentException("Unknown enum member", nameof(result));
+            }
+        }
+
+        /// <summary>
+        /// Given a time offset, whether the <see cref="HitObject"/> can ever be hit in the future with a non-<see cref="HitResult.Miss"/> result.
+        /// This happens if <paramref name="timeOffset"/> is less than what is required for <see cref="LowestSuccessfulHitResult"/>.
+        /// </summary>
+        /// <param name="timeOffset">The time offset.</param>
+        /// <returns>Whether the <see cref="HitObject"/> can be hit at any point in the future from this time offset.</returns>
+        public bool CanBeHit(double timeOffset) => timeOffset <= WindowFor(LowestSuccessfulHitResult());
+
+        /// <summary>
+        /// Retrieve a valid list of <see cref="DifficultyRange"/>s representing hit windows.
+        /// Defaults are provided but can be overridden to customise for a ruleset.
+        /// </summary>
+        protected virtual DifficultyRange[] GetRanges() => base_ranges;
+
+        public class EmptyHitWindows : HitWindows
+        {
+            private static readonly DifficultyRange[] ranges =
+            {
+                new DifficultyRange(HitResult.Perfect, 0, 0, 0),
+                new DifficultyRange(HitResult.Miss, 0, 0, 0),
+            };
+
+            public override bool IsHitResultAllowed(HitResult result)
+            {
+                switch (result)
+                {
+                    case HitResult.Perfect:
+                    case HitResult.Miss:
+                        return true;
+                }
+
+                return false;
+            }
+
+            protected override DifficultyRange[] GetRanges() => ranges;
+        }
+    }
+
+    public struct DifficultyRange
+    {
+        public readonly HitResult Result;
+
+        public double Min;
+        public double Average;
+        public double Max;
+
+        public DifficultyRange(HitResult result, double min, double average, double max)
+        {
+            Result = result;
+
+            Min = min;
+            Average = average;
+            Max = max;
+        }
+    }
+}

--- a/starrating/DifficultyCalculator.cs
+++ b/starrating/DifficultyCalculator.cs
@@ -64,8 +64,8 @@ namespace MapsetParser.starrating
                 {
                     foreach (Skill s in skills)
                     {
-                        s.SaveCurrentPeak();
-                        s.StartNewSectionFrom(currentSectionEnd);
+                        (s as StrainSkill)?.saveCurrentPeak();
+                        (s as StrainSkill)?.startNewSectionFrom(currentSectionEnd, h);
                     }
 
                     currentSectionEnd += sectionLength;
@@ -77,7 +77,7 @@ namespace MapsetParser.starrating
 
             // The peak strain will not be saved for the last section in the above loop
             foreach (Skill s in skills)
-                s.SaveCurrentPeak();
+                (s as StrainSkill)?.saveCurrentPeak();
 
             return CreateDifficultyAttributes(beatmap, skills);
         }
@@ -96,14 +96,12 @@ namespace MapsetParser.starrating
         /// <param name="beatmap">The <see cref="IBeatmap"/> whose difficulty was calculated.</param>
         /// <param name="mods">The <see cref="Mod"/>s that difficulty was calculated with.</param>
         /// <param name="skills">The skills which processed the beatmap.</param>
-        /// <param name="clockRate">The rate at which the gameplay clock is run at.</param>
         protected abstract DifficultyAttributes CreateDifficultyAttributes(Beatmap beatmap, Skill[] skills);
 
         /// <summary>
         /// Enumerates <see cref="DifficultyHitObject"/>s to be processed from <see cref="HitObject"/>s in the <see cref="IBeatmap"/>.
         /// </summary>
         /// <param name="beatmap">The <see cref="IBeatmap"/> providing the <see cref="HitObject"/>s to enumerate.</param>
-        /// <param name="clockRate">The rate at which the gameplay clock is run at.</param>
         /// <returns>The enumerated <see cref="DifficultyHitObject"/>s.</returns>
         protected abstract IEnumerable<DifficultyHitObject> CreateDifficultyHitObjects(Beatmap beatmap);
 

--- a/starrating/IBeatmapDifficultyInfo.cs
+++ b/starrating/IBeatmapDifficultyInfo.cs
@@ -1,0 +1,96 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace MapsetParser.starrating
+{
+    /// <summary>
+    /// A representation of all top-level difficulty settings for a beatmap.
+    /// </summary>
+    public interface IBeatmapDifficultyInfo
+    {
+        /// <summary>
+        /// The default value used for all difficulty settings except <see cref="SliderMultiplier"/> and <see cref="SliderTickRate"/>.
+        /// </summary>
+        const float DEFAULT_DIFFICULTY = 5;
+
+        /// <summary>
+        /// The drain rate of the associated beatmap.
+        /// </summary>
+        float DrainRate { get; }
+
+        /// <summary>
+        /// The circle size of the associated beatmap.
+        /// </summary>
+        float CircleSize { get; }
+
+        /// <summary>
+        /// The overall difficulty of the associated beatmap.
+        /// </summary>
+        float OverallDifficulty { get; }
+
+        /// <summary>
+        /// The approach rate of the associated beatmap.
+        /// </summary>
+        float ApproachRate { get; }
+
+        /// <summary>
+        /// The base slider velocity of the associated beatmap.
+        /// This was known as "SliderMultiplier" in the .osu format and stable editor.
+        /// </summary>
+        double SliderMultiplier { get; }
+
+        /// <summary>
+        /// The slider tick rate of the associated beatmap.
+        /// </summary>
+        double SliderTickRate { get; }
+
+        /// <summary>
+        /// Maps a difficulty value [0, 10] to a two-piece linear range of values.
+        /// </summary>
+        /// <param name="difficulty">The difficulty value to be mapped.</param>
+        /// <param name="min">Minimum of the resulting range which will be achieved by a difficulty value of 0.</param>
+        /// <param name="mid">Midpoint of the resulting range which will be achieved by a difficulty value of 5.</param>
+        /// <param name="max">Maximum of the resulting range which will be achieved by a difficulty value of 10.</param>
+        /// <returns>Value to which the difficulty value maps in the specified range.</returns>
+        static double DifficultyRange(double difficulty, double min, double mid, double max)
+        {
+            if (difficulty > 5)
+                return mid + (max - mid) * DifficultyRange(difficulty);
+            if (difficulty < 5)
+                return mid + (mid - min) * DifficultyRange(difficulty);
+
+            return mid;
+        }
+
+        /// <summary>
+        /// Maps a difficulty value [0, 10] to a linear range of [-1, 1].
+        /// </summary>
+        /// <param name="difficulty">The difficulty value to be mapped.</param>
+        /// <returns>Value to which the difficulty value maps in the specified range.</returns>
+        static double DifficultyRange(double difficulty) => (difficulty - 5) / 5;
+
+        /// <summary>
+        /// Maps a difficulty value [0, 10] to a two-piece linear range of values.
+        /// </summary>
+        /// <param name="difficulty">The difficulty value to be mapped.</param>
+        /// <param name="range">The values that define the two linear ranges.
+        /// <list type="table">
+        ///   <item>
+        ///     <term>od0</term>
+        ///     <description>Minimum of the resulting range which will be achieved by a difficulty value of 0.</description>
+        ///   </item>
+        ///   <item>
+        ///     <term>od5</term>
+        ///     <description>Midpoint of the resulting range which will be achieved by a difficulty value of 5.</description>
+        ///   </item>
+        ///   <item>
+        ///     <term>od10</term>
+        ///     <description>Maximum of the resulting range which will be achieved by a difficulty value of 10.</description>
+        ///   </item>
+        /// </list>
+        /// </param>
+        /// <returns>Value to which the difficulty value maps in the specified range.</returns>
+        static double DifficultyRange(double difficulty, (double od0, double od5, double od10) range)
+            => DifficultyRange(difficulty, range.od0, range.od5, range.od10);
+    }
+}

--- a/starrating/osu/preprocessing/OsuDifficultyHitObject.cs
+++ b/starrating/osu/preprocessing/OsuDifficultyHitObject.cs
@@ -41,7 +41,7 @@ namespace MapsetParser.starrating.osu.preprocessing
         private readonly HitObject lastObject;
 
         public OsuDifficultyHitObject(HitObject hitObject, HitObject lastLastObject, HitObject lastObject)
-            : base(hitObject, lastObject)
+            : base(hitObject, lastObject, null, 0)
         {
             this.lastLastObject = lastLastObject;
             this.lastObject = lastObject;

--- a/starrating/osu/skills/Aim.cs
+++ b/starrating/osu/skills/Aim.cs
@@ -12,7 +12,7 @@ namespace MapsetParser.starrating.osu.skills
     /// <summary>
     /// Represents the skill required to correctly aim at every object in the map with a uniform CircleSize and normalized distances.
     /// </summary>
-    public class Aim : Skill
+    public class Aim : StrainDecaySkill
     {
         private const double angle_bonus_begin = Math.PI / 3;
         private const double timing_threshold = 107;
@@ -31,9 +31,9 @@ namespace MapsetParser.starrating.osu.skills
 
             double result = 0;
 
-            if (Previous.Count > 0)
+            if (current.Index >= 1)
             {
-                var osuPrevious = (OsuDifficultyHitObject)Previous[0];
+                var osuPrevious = (OsuDifficultyHitObject)current.Previous(0);
 
                 if (osuCurrent.Angle != null && osuCurrent.Angle.Value > angle_bonus_begin)
                 {

--- a/starrating/osu/skills/Speed.cs
+++ b/starrating/osu/skills/Speed.cs
@@ -12,7 +12,7 @@ namespace MapsetParser.starrating.osu.skills
     /// <summary>
     /// Represents the skill required to press keys with regards to keeping up with the speed at which objects need to be hit.
     /// </summary>
-    public class Speed : Skill
+    public class Speed : StrainDecaySkill
     {
         private const double single_spacing_threshold = 125;
 

--- a/starrating/preprocessing/DifficultyHitObject.cs
+++ b/starrating/preprocessing/DifficultyHitObject.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
+using System.Linq;
 using MapsetParser.objects;
 
 namespace MapsetParser.starrating.preprocessing
@@ -10,6 +12,13 @@ namespace MapsetParser.starrating.preprocessing
     /// </summary>
     public class DifficultyHitObject
     {
+        private readonly IReadOnlyList<DifficultyHitObject> difficultyHitObjects;
+
+        /// <summary>
+        /// The index of this <see cref="DifficultyHitObject"/> in the list of all <see cref="DifficultyHitObject"/>s.
+        /// </summary>
+        public int Index;
+
         /// <summary>
         /// The <see cref="HitObject"/> this <see cref="DifficultyHitObject"/> wraps.
         /// </summary>
@@ -26,16 +35,35 @@ namespace MapsetParser.starrating.preprocessing
         public readonly double DeltaTime;
 
         /// <summary>
+        /// Start time of <see cref="BaseObject"/>.
+        /// </summary>
+        public readonly double StartTime;
+
+        /// <summary>
+        /// End time of <see cref="BaseObject"/>.
+        /// </summary>
+        public readonly double EndTime;
+
+        /// <summary>
         /// Creates a new <see cref="DifficultyHitObject"/>.
         /// </summary>
         /// <param name="hitObject">The <see cref="HitObject"/> which this <see cref="DifficultyHitObject"/> wraps.</param>
         /// <param name="lastObject">The last <see cref="HitObject"/> which occurs before <paramref name="hitObject"/> in the beatmap.</param>
-        /// <param name="clockRate">The rate at which the gameplay clock is run at.</param>
-        public DifficultyHitObject(HitObject hitObject, HitObject lastObject)
+        /// <param name="objects">The list of <see cref="DifficultyHitObject"/>s in the current beatmap.</param>
+        /// <param name="index">The index of this <see cref="DifficultyHitObject"/> in <paramref name="objects"/> list.</param>
+        public DifficultyHitObject(HitObject hitObject, HitObject lastObject, List<DifficultyHitObject> objects, int index)
         {
+            difficultyHitObjects = objects;
+            Index = index;
             BaseObject = hitObject;
             LastObject = lastObject;
-            DeltaTime = hitObject.time - lastObject.time;
+            DeltaTime = (hitObject.time - lastObject.time);
+            StartTime = hitObject.time;
+            EndTime = hitObject.GetEndTime();
         }
+
+        public DifficultyHitObject Previous(int backwardsIndex) => difficultyHitObjects.ElementAtOrDefault(Index - (backwardsIndex + 1));
+
+        public DifficultyHitObject Next(int forwardsIndex) => difficultyHitObjects.ElementAtOrDefault(Index + (forwardsIndex + 1));
     }
 }

--- a/starrating/skills/Skill.cs
+++ b/starrating/skills/Skill.cs
@@ -3,119 +3,26 @@
 
 using MapsetParser.starrating.preprocessing;
 using MapsetParser.starrating.utils;
-using System;
-using System.Collections.Generic;
-using System.Linq;
 
 namespace MapsetParser.starrating.skills
 {
     /// <summary>
-    /// Used to processes strain values of <see cref="DifficultyHitObject"/>s, keep track of strain levels caused by the processed objects
-    /// and to calculate a final difficulty value representing the difficulty of hitting all the processed objects.
+    /// A bare minimal abstract skill for fully custom skill implementations.
     /// </summary>
+    /// <remarks>
+    /// This class should be considered a "processing" class and not persisted.
+    /// </remarks>
     public abstract class Skill
     {
-        /// <summary>
-        /// The peak strain for each <see cref="DifficultyCalculator.SectionLength"/> section of the beatmap.
-        /// </summary>
-        public IReadOnlyList<double> StrainPeaks => strainPeaks;
-
-        /// <summary>
-        /// Strain values are multiplied by this number for the given skill. Used to balance the value of different skills between each other.
-        /// </summary>
-        protected abstract double SkillMultiplier { get; }
-
-        /// <summary>
-        /// Determines how quickly strain decays for the given skill.
-        /// For example a value of 0.15 indicates that strain decays to 15% of its original value in one second.
-        /// </summary>
-        protected abstract double StrainDecayBase { get; }
-
-        /// <summary>
-        /// The weight by which each strain value decays.
-        /// </summary>
-        protected virtual double DecayWeight => 0.9;
-
-        /// <summary>
-        /// <see cref="DifficultyHitObject"/>s that were processed previously. They can affect the strain values of the following objects.
-        /// </summary>
-        protected readonly LimitedCapacityStack<DifficultyHitObject> Previous = new LimitedCapacityStack<DifficultyHitObject>(2); // Contained objects not used yet
-
-        /// <summary>
-        /// The current strain level.
-        /// </summary>
-        protected double CurrentStrain { get; private set; } = 1;
-
-        private double currentSectionPeak = 1; // We also keep track of the peak strain level in the current section.
-
-        private readonly List<double> strainPeaks = new List<double>();
-
-        /// <summary>
-        /// Process a <see cref="DifficultyHitObject"/> and update current strain values accordingly.
-        /// </summary>
-        public void Process(DifficultyHitObject current)
+        protected Skill()
         {
-            CurrentStrain *= StrainDecay(current.DeltaTime);
-            CurrentStrain += StrainValueOf(current) * SkillMultiplier;
-
-            currentSectionPeak = Math.Max(CurrentStrain, currentSectionPeak);
-
-            Previous.Push(current);
         }
 
         /// <summary>
-        /// Saves the current peak strain level to the list of strain peaks, which will be used to calculate an overall difficulty.
+        /// Process a <see cref="DifficultyHitObject"/>.
         /// </summary>
-        public void SaveCurrentPeak()
-        {
-            if (Previous.Count > 0)
-                strainPeaks.Add(currentSectionPeak);
-        }
-
-        /// <summary>
-        /// Sets the initial strain level for a new section.
-        /// </summary>
-        /// <param name="time">The beginning of the new section in milliseconds.</param>
-        public void StartNewSectionFrom(double time)
-        {
-            // The maximum strain of the new section is not zero by default, strain decays as usual regardless of section boundaries.
-            // This means we need to capture the strain level at the beginning of the new section, and use that as the initial peak level.
-            if (Previous.Count > 0)
-                currentSectionPeak = GetPeakStrain(time);
-        }
-
-        /// <summary>
-        /// Retrieves the peak strain at a point in time.
-        /// </summary>
-        /// <param name="time">The time to retrieve the peak strain at.</param>
-        /// <returns>The peak strain.</returns>
-        protected virtual double GetPeakStrain(double time) => CurrentStrain * StrainDecay(time - Previous[0].BaseObject.time);
-
-        /// <summary>
-        /// Returns the calculated difficulty value representing all processed <see cref="DifficultyHitObject"/>s.
-        /// </summary>
-        public double DifficultyValue()
-        {
-            double difficulty = 0;
-            double weight = 1;
-
-            // Difficulty is the weighted sum of the highest strains from every section.
-            // We're sorting from highest to lowest strain.
-            foreach (double strain in strainPeaks.OrderByDescending(d => d))
-            {
-                difficulty += strain * weight;
-                weight *= DecayWeight;
-            }
-
-            return difficulty;
-        }
-
-        /// <summary>
-        /// Calculates the strain value of a <see cref="DifficultyHitObject"/>. This value is affected by previously processed objects.
-        /// </summary>
-        protected abstract double StrainValueOf(DifficultyHitObject current);
-
-        private double StrainDecay(double ms) => Math.Pow(StrainDecayBase, ms / 1000);
+        /// <param name="current">The <see cref="DifficultyHitObject"/> to process.</param>
+        public abstract void Process(DifficultyHitObject current);
 
         public abstract string SkillName();
         public override string ToString() => SkillName();
@@ -128,6 +35,9 @@ namespace MapsetParser.starrating.skills
             return skill.SkillName() == this.SkillName();
         }
 
-        public override int GetHashCode() => SkillName().GetHashCode();
+        /// <summary>
+        /// Returns the calculated difficulty value representing all <see cref="DifficultyHitObject"/>s that have been processed up to this point.
+        /// </summary>
+        public abstract double DifficultyValue();
     }
 }

--- a/starrating/skills/StrainDecaySkill.cs
+++ b/starrating/skills/StrainDecaySkill.cs
@@ -1,0 +1,59 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using MapsetParser.starrating.preprocessing;
+
+namespace MapsetParser.starrating.skills
+{
+    /// <summary>
+    /// Used to processes strain values of <see cref="DifficultyHitObject"/>s, keep track of strain levels caused by the processed objects
+    /// and to calculate a final difficulty value representing the difficulty of hitting all the processed objects.
+    /// </summary>
+    public abstract class StrainDecaySkill : StrainSkill
+    {
+        /// <summary>
+        /// Strain values are multiplied by this number for the given skill. Used to balance the value of different skills between each other.
+        /// </summary>
+        protected abstract double SkillMultiplier { get; }
+
+        /// <summary>
+        /// Determines how quickly strain decays for the given skill.
+        /// For example a value of 0.15 indicates that strain decays to 15% of its original value in one second.
+        /// </summary>
+        protected abstract double StrainDecayBase { get; }
+
+        /// <summary>
+        /// The current strain level.
+        /// </summary>
+        protected double CurrentStrain { get; private set; }
+
+        protected StrainDecaySkill()
+            : base()
+        {
+        }
+
+        protected override double CalculateInitialStrain(double time, DifficultyHitObject current) {
+            if (current.Index == 0)
+            {
+                return CurrentStrain;
+            }
+            return CurrentStrain * strainDecay(time - current.Previous(0).StartTime);
+        }
+
+        protected override double StrainValueAt(DifficultyHitObject current)
+        {
+            CurrentStrain *= strainDecay(current.DeltaTime);
+            CurrentStrain += StrainValueOf(current) * SkillMultiplier;
+
+            return CurrentStrain;
+        }
+
+        /// <summary>
+        /// Calculates the strain value of a <see cref="DifficultyHitObject"/>. This value is affected by previously processed objects.
+        /// </summary>
+        protected abstract double StrainValueOf(DifficultyHitObject current);
+
+        private double strainDecay(double ms) => Math.Pow(StrainDecayBase, ms / 1000);
+    }
+}

--- a/starrating/skills/StrainSkill.cs
+++ b/starrating/skills/StrainSkill.cs
@@ -1,0 +1,119 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using MapsetParser.starrating.preprocessing;
+
+namespace MapsetParser.starrating.skills
+{
+    /// <summary>
+    /// Used to processes strain values of <see cref="DifficultyHitObject"/>s, keep track of strain levels caused by the processed objects
+    /// and to calculate a final difficulty value representing the difficulty of hitting all the processed objects.
+    /// </summary>
+    public abstract class StrainSkill : Skill
+    {
+        /// <summary>
+        /// The weight by which each strain value decays.
+        /// </summary>
+        protected virtual double DecayWeight => 0.9;
+
+        /// <summary>
+        /// The length of each strain section.
+        /// </summary>
+        protected virtual int SectionLength => 400;
+
+        private double currentSectionPeak; // We also keep track of the peak strain level in the current section.
+
+        private double currentSectionEnd;
+
+        private readonly List<double> strainPeaks = new List<double>();
+
+        protected StrainSkill()
+            : base()
+        {
+        }
+
+        /// <summary>
+        /// Returns the strain value at <see cref="DifficultyHitObject"/>. This value is calculated with or without respect to previous objects.
+        /// </summary>
+        protected abstract double StrainValueAt(DifficultyHitObject current);
+
+        /// <summary>
+        /// Process a <see cref="DifficultyHitObject"/> and update current strain values accordingly.
+        /// </summary>
+        public sealed override void Process(DifficultyHitObject current)
+        {
+            // The first object doesn't generate a strain, so we begin with an incremented section end
+            if (current.Index == 0)
+                currentSectionEnd = Math.Ceiling(current.StartTime / SectionLength) * SectionLength;
+
+            while (current.StartTime > currentSectionEnd)
+            {
+                saveCurrentPeak();
+                startNewSectionFrom(currentSectionEnd, current);
+                currentSectionEnd += SectionLength;
+            }
+
+            currentSectionPeak = Math.Max(StrainValueAt(current), currentSectionPeak);
+        }
+
+        /// <summary>
+        /// Saves the current peak strain level to the list of strain peaks, which will be used to calculate an overall difficulty.
+        /// </summary>
+        public void saveCurrentPeak()
+        {
+            strainPeaks.Add(currentSectionPeak);
+        }
+
+        /// <summary>
+        /// Sets the initial strain level for a new section.
+        /// </summary>
+        /// <param name="time">The beginning of the new section in milliseconds.</param>
+        /// <param name="current">The current hit object.</param>
+        public void startNewSectionFrom(double time, DifficultyHitObject current)
+        {
+            // The maximum strain of the new section is not zero by default
+            // This means we need to capture the strain level at the beginning of the new section, and use that as the initial peak level.
+            currentSectionPeak = CalculateInitialStrain(time, current);
+        }
+
+        /// <summary>
+        /// Retrieves the peak strain at a point in time.
+        /// </summary>
+        /// <param name="time">The time to retrieve the peak strain at.</param>
+        /// <param name="current">The current hit object.</param>
+        /// <returns>The peak strain.</returns>
+        protected abstract double CalculateInitialStrain(double time, DifficultyHitObject current);
+
+        /// <summary>
+        /// Returns a live enumerable of the peak strains for each <see cref="SectionLength"/> section of the beatmap,
+        /// including the peak of the current section.
+        /// </summary>
+        public IEnumerable<double> GetCurrentStrainPeaks() => strainPeaks.Append(currentSectionPeak);
+
+        /// <summary>
+        /// Returns the calculated difficulty value representing all <see cref="DifficultyHitObject"/>s that have been processed up to this point.
+        /// </summary>
+        public override double DifficultyValue()
+        {
+            double difficulty = 0;
+            double weight = 1;
+
+            // Sections with 0 strain are excluded to avoid worst-case time complexity of the following sort (e.g. /b/2351871).
+            // These sections will not contribute to the difficulty.
+            var peaks = GetCurrentStrainPeaks().Where(p => p > 0);
+
+            // Difficulty is the weighted sum of the highest strains from every section.
+            // We're sorting from highest to lowest strain.
+            foreach (double strain in peaks.OrderByDescending(d => d))
+            {
+                difficulty += strain * weight;
+                weight *= DecayWeight;
+            }
+
+            return difficulty;
+        }
+    }
+}

--- a/starrating/taiko/TaikoDifficultyAttributes.cs
+++ b/starrating/taiko/TaikoDifficultyAttributes.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace MapsetParser.starrating.taiko
+{
+    public class TaikoDifficultyAttributes : DifficultyAttributes
+    {
+        /// <summary>
+        /// The difficulty corresponding to the stamina skill.
+        /// </summary>
+        public double StaminaDifficulty;
+
+        /// <summary>
+        /// The difficulty corresponding to the rhythm skill.
+        /// </summary>
+        public double RhythmDifficulty;
+
+        /// <summary>
+        /// The difficulty corresponding to the colour skill.
+        /// </summary>
+        public double ColourDifficulty;
+
+        /// <summary>
+        /// The difficulty corresponding to the hardest parts of the map.
+        /// </summary>
+        public double PeakDifficulty;
+
+        /// <summary>
+        /// The perceived hit window for a GREAT hit inclusive of rate-adjusting mods (DT/HT/etc).
+        /// </summary>
+        public double GreatHitWindow;
+    }
+}

--- a/starrating/taiko/TaikoDifficultyCalculator.cs
+++ b/starrating/taiko/TaikoDifficultyCalculator.cs
@@ -1,0 +1,100 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using MapsetParser.objects;
+using MapsetParser.objects.hitobjects;
+using MapsetParser.objects.taiko;
+using MapsetParser.scoring;
+using MapsetParser.starrating.preprocessing;
+using MapsetParser.starrating.skills;
+using MapsetParser.starrating.taiko.preprocessing;
+using MapsetParser.starrating.taiko.preprocessing.Colour;
+using MapsetParser.starrating.taiko.scoring;
+using MapsetParser.starrating.taiko.skills;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace MapsetParser.starrating.taiko
+{
+    public class TaikoDifficultyCalculator : DifficultyCalculator
+    {
+        private const double difficulty_multiplier = 1.35;
+
+        public TaikoDifficultyCalculator(Beatmap beatmap)
+            : base(beatmap)
+        {
+        }
+
+        protected override Skill[] CreateSkills(Beatmap beatmap)
+        {
+            return new Skill[]
+            {
+                new Peaks()
+            };
+        }
+
+        protected override IEnumerable<DifficultyHitObject> CreateDifficultyHitObjects(Beatmap beatmap)
+        {
+            List<DifficultyHitObject> difficultyHitObjects = new List<DifficultyHitObject>();
+            List<TaikoDifficultyHitObject> centreObjects = new List<TaikoDifficultyHitObject>();
+            List<TaikoDifficultyHitObject> rimObjects = new List<TaikoDifficultyHitObject>();
+            List<TaikoDifficultyHitObject> noteObjects = new List<TaikoDifficultyHitObject>();
+
+            for (int i = 2; i < beatmap.hitObjects.Count; i++)
+            {
+                difficultyHitObjects.Add(
+                    new TaikoDifficultyHitObject(
+                        beatmap.hitObjects[i], beatmap.hitObjects[i - 1], beatmap.hitObjects[i - 2], difficultyHitObjects,
+                        centreObjects, rimObjects, noteObjects, difficultyHitObjects.Count)
+                );
+            }
+
+            TaikoColourDifficultyPreprocessor.ProcessAndAssign(difficultyHitObjects);
+
+            return difficultyHitObjects;
+        }
+
+        protected override DifficultyAttributes CreateDifficultyAttributes(Beatmap beatmap, Skill[] skills)
+        {
+            if (beatmap.hitObjects.Count == 0)
+                return new TaikoDifficultyAttributes {};
+
+            var combined = (Peaks)skills[0];
+
+            double colourRating = combined.ColourDifficultyValue * difficulty_multiplier;
+            double rhythmRating = combined.RhythmDifficultyValue * difficulty_multiplier;
+            double staminaRating = combined.StaminaDifficultyValue * difficulty_multiplier;
+
+            double combinedRating = combined.DifficultyValue() * difficulty_multiplier;
+            double starRating = rescale(combinedRating * 1.4);
+
+            HitWindows hitWindows = new TaikoHitWindows();
+            hitWindows.SetDifficulty(beatmap.difficultySettings.overallDifficulty);
+
+            TaikoDifficultyAttributes attributes = new TaikoDifficultyAttributes
+            {
+                StarRating = starRating,
+                StaminaDifficulty = staminaRating,
+                RhythmDifficulty = rhythmRating,
+                ColourDifficulty = colourRating,
+                PeakDifficulty = combinedRating,
+                GreatHitWindow = hitWindows.WindowFor(HitResult.Great),
+                MaxCombo = beatmap.hitObjects.Count(h => h is Hit),
+            };
+
+            return attributes;
+        }
+
+        /// <summary>
+        /// Applies a final re-scaling of the star rating.
+        /// </summary>
+        /// <param name="sr">The raw star rating value before re-scaling.</param>
+        private double rescale(double sr)
+        {
+            if (sr < 0) return sr;
+
+            return 10.43 * Math.Log(sr / 8 + 1);
+        }
+    }
+}

--- a/starrating/taiko/evaluators/ColourEvaluator.cs
+++ b/starrating/taiko/evaluators/ColourEvaluator.cs
@@ -1,0 +1,67 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using MapsetParser.starrating.preprocessing;
+using MapsetParser.starrating.taiko.preprocessing;
+using MapsetParser.starrating.taiko.preprocessing.Colour;
+using MapsetParser.starrating.taiko.preprocessing.Colour.Data;
+
+namespace MapsetParser.starrating.taiko.evaluators
+{
+    public class ColourEvaluator
+    {
+        /// <summary>
+        /// A sigmoid function. It gives a value between (middle - height/2) and (middle + height/2).
+        /// </summary>
+        /// <param name="val">The input value.</param>
+        /// <param name="center">The center of the sigmoid, where the largest gradient occurs and value is equal to middle.</param>
+        /// <param name="width">The radius of the sigmoid, outside of which values are near the minimum/maximum.</param>
+        /// <param name="middle">The middle of the sigmoid output.</param>
+        /// <param name="height">The height of the sigmoid output. This will be equal to max value - min value.</param>
+        private static double sigmoid(double val, double center, double width, double middle, double height)
+        {
+            double sigmoid = Math.Tanh(Math.E * -(val - center) / width);
+            return sigmoid * (height / 2) + middle;
+        }
+
+        /// <summary>
+        /// Evaluate the difficulty of the first note of a <see cref="MonoStreak"/>.
+        /// </summary>
+        public static double EvaluateDifficultyOf(MonoStreak monoStreak)
+        {
+            return sigmoid(monoStreak.Index, 2, 2, 0.5, 1) * EvaluateDifficultyOf(monoStreak.Parent) * 0.5;
+        }
+
+        /// <summary>
+        /// Evaluate the difficulty of the first note of a <see cref="AlternatingMonoPattern"/>.
+        /// </summary>
+        public static double EvaluateDifficultyOf(AlternatingMonoPattern alternatingMonoPattern)
+        {
+            return sigmoid(alternatingMonoPattern.Index, 2, 2, 0.5, 1) * EvaluateDifficultyOf(alternatingMonoPattern.Parent);
+        }
+
+        /// <summary>
+        /// Evaluate the difficulty of the first note of a <see cref="RepeatingHitPatterns"/>.
+        /// </summary>
+        public static double EvaluateDifficultyOf(RepeatingHitPatterns repeatingHitPattern)
+        {
+            return 2 * (1 - sigmoid(repeatingHitPattern.RepetitionInterval, 2, 2, 0.5, 1));
+        }
+
+        public static double EvaluateDifficultyOf(DifficultyHitObject hitObject)
+        {
+            TaikoDifficultyHitObjectColour colour = ((TaikoDifficultyHitObject)hitObject).Colour;
+            double difficulty = 0.0d;
+
+            if (colour.MonoStreak?.FirstHitObject == hitObject) // Difficulty for MonoStreak
+                difficulty += EvaluateDifficultyOf(colour.MonoStreak);
+            if (colour.AlternatingMonoPattern?.FirstHitObject == hitObject) // Difficulty for AlternatingMonoPattern
+                difficulty += EvaluateDifficultyOf(colour.AlternatingMonoPattern);
+            if (colour.RepeatingHitPattern?.FirstHitObject == hitObject) // Difficulty for RepeatingHitPattern
+                difficulty += EvaluateDifficultyOf(colour.RepeatingHitPattern);
+
+            return difficulty;
+        }
+    }
+}

--- a/starrating/taiko/evaluators/StaminaEvaluator.cs
+++ b/starrating/taiko/evaluators/StaminaEvaluator.cs
@@ -1,0 +1,75 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using MapsetParser.objects.taiko;
+using MapsetParser.starrating.preprocessing;
+using MapsetParser.starrating.taiko.preprocessing;
+
+namespace MapsetParser.starrating.taiko.evaluators
+{
+    public class StaminaEvaluator
+    {
+        /// <summary>
+        /// Applies a speed bonus dependent on the time since the last hit performed using this finger.
+        /// </summary>
+        /// <param name="interval">The interval between the current and previous note hit using the same finger.</param>
+        private static double speedBonus(double interval)
+        {
+            // Interval is capped at a very small value to prevent infinite values.
+            interval = Math.Max(interval, 1);
+
+            return 30 / interval;
+        }
+
+        /// <summary>
+        /// Determines the number of fingers available to hit the current <see cref="TaikoDifficultyHitObject"/>.
+        /// Any mono notes that is more than 300ms apart from a colour change will be considered to have more than 2
+        /// fingers available, since players can hit the same key with multiple fingers.
+        /// </summary>
+        private static int availableFingersFor(TaikoDifficultyHitObject hitObject)
+        {
+            DifficultyHitObject? previousColourChange = hitObject.Colour.PreviousColourChange;
+            DifficultyHitObject? nextColourChange = hitObject.Colour.NextColourChange;
+
+            if (previousColourChange != null && hitObject.StartTime - previousColourChange.StartTime < 300)
+            {
+                return 2;
+            }
+
+            if (nextColourChange != null && nextColourChange.StartTime - hitObject.StartTime < 300)
+            {
+                return 2;
+            }
+
+            return 4;
+        }
+
+        /// <summary>
+        /// Evaluates the minimum mechanical stamina required to play the current object. This is calculated using the
+        /// maximum possible interval between two hits using the same key, by alternating available fingers for each colour.
+        /// </summary>
+        public static double EvaluateDifficultyOf(DifficultyHitObject current)
+        {
+            if (!(current.BaseObject is Hit))
+            {
+                return 0.0;
+            }
+
+            // Find the previous hit object hit by the current finger, which is n notes prior, n being the number of
+            // available fingers.
+            TaikoDifficultyHitObject taikoCurrent = (TaikoDifficultyHitObject)current;
+            TaikoDifficultyHitObject? keyPrevious = taikoCurrent.PreviousMono(availableFingersFor(taikoCurrent) - 1);
+
+            if (keyPrevious == null)
+            {
+                // There is no previous hit object hit by the current finger
+                return 0.0;
+            }
+
+            double objectStrain = 0.5; // Add a base strain to all objects
+            objectStrain += speedBonus(taikoCurrent.StartTime - keyPrevious.StartTime);
+            return objectStrain;
+        }
+    }
+}

--- a/starrating/taiko/preprocessing/TaikoDifficultyHitObject.cs
+++ b/starrating/taiko/preprocessing/TaikoDifficultyHitObject.cs
@@ -1,0 +1,142 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using MapsetParser.objects;
+using MapsetParser.objects.taiko;
+using MapsetParser.starrating.preprocessing;
+using MapsetParser.starrating.taiko.preprocessing.Colour;
+using MapsetParser.starrating.taiko.preprocessing.Rhythm;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Numerics;
+
+namespace MapsetParser.starrating.taiko.preprocessing
+{
+    /// <summary>
+    /// Represents a single hit object in taiko difficulty calculation.
+    /// </summary>
+    public class TaikoDifficultyHitObject : DifficultyHitObject
+    {
+        /// <summary>
+        /// The list of all <see cref="TaikoDifficultyHitObject"/> of the same colour as this <see cref="TaikoDifficultyHitObject"/> in the beatmap.
+        /// </summary>
+        private readonly IReadOnlyList<TaikoDifficultyHitObject>? monoDifficultyHitObjects;
+
+        /// <summary>
+        /// The index of this <see cref="TaikoDifficultyHitObject"/> in <see cref="monoDifficultyHitObjects"/>.
+        /// </summary>
+        public readonly int MonoIndex;
+
+        /// <summary>
+        /// The list of all <see cref="TaikoDifficultyHitObject"/> that is either a regular note or finisher in the beatmap
+        /// </summary>
+        private readonly IReadOnlyList<TaikoDifficultyHitObject> noteDifficultyHitObjects;
+
+        /// <summary>
+        /// The index of this <see cref="TaikoDifficultyHitObject"/> in <see cref="noteDifficultyHitObjects"/>.
+        /// </summary>
+        public readonly int NoteIndex;
+
+        /// <summary>
+        /// The rhythm required to hit this hit object.
+        /// </summary>
+        public readonly TaikoDifficultyHitObjectRhythm Rhythm;
+
+        /// <summary>
+        /// Colour data for this hit object. This is used by colour evaluator to calculate colour difficulty, but can be used
+        /// by other skills in the future.
+        /// </summary>
+        public readonly TaikoDifficultyHitObjectColour Colour;
+
+        /// <summary>
+        /// Creates a new difficulty hit object.
+        /// </summary>
+        /// <param name="hitObject">The gameplay <see cref="HitObject"/> associated with this difficulty object.</param>
+        /// <param name="lastObject">The gameplay <see cref="HitObject"/> preceding <paramref name="hitObject"/>.</param>
+        /// <param name="lastLastObject">The gameplay <see cref="HitObject"/> preceding <paramref name="lastObject"/>.</param>
+        /// <param name="objects">The list of all <see cref="DifficultyHitObject"/>s in the current beatmap.</param>
+        /// <param name="centreHitObjects">The list of centre (don) <see cref="DifficultyHitObject"/>s in the current beatmap.</param>
+        /// <param name="rimHitObjects">The list of rim (kat) <see cref="DifficultyHitObject"/>s in the current beatmap.</param>
+        /// <param name="noteObjects">The list of <see cref="DifficultyHitObject"/>s that is a hit (i.e. not a drumroll or swell) in the current beatmap.</param>
+        /// <param name="index">The position of this <see cref="DifficultyHitObject"/> in the <paramref name="objects"/> list.</param>
+        public TaikoDifficultyHitObject(HitObject hitObject, HitObject lastObject, HitObject lastLastObject,
+                                        List<DifficultyHitObject> objects,
+                                        List<TaikoDifficultyHitObject> centreHitObjects,
+                                        List<TaikoDifficultyHitObject> rimHitObjects,
+                                        List<TaikoDifficultyHitObject> noteObjects, int index)
+            : base(hitObject, lastObject, objects, index)
+        {
+            noteDifficultyHitObjects = noteObjects;
+
+            // Create the Colour object, its properties should be filled in by TaikoDifficultyPreprocessor
+            Colour = new TaikoDifficultyHitObjectColour();
+            Rhythm = getClosestRhythm(lastObject, lastLastObject);
+
+            switch ((hitObject as Hit)?.Type)
+            {
+                case HitType.Centre:
+                    MonoIndex = centreHitObjects.Count;
+                    centreHitObjects.Add(this);
+                    monoDifficultyHitObjects = centreHitObjects;
+                    break;
+
+                case HitType.Rim:
+                    MonoIndex = rimHitObjects.Count;
+                    rimHitObjects.Add(this);
+                    monoDifficultyHitObjects = rimHitObjects;
+                    break;
+            }
+
+            if (hitObject is Hit)
+            {
+                NoteIndex = noteObjects.Count;
+                noteObjects.Add(this);
+            }
+        }
+
+        /// <summary>
+        /// List of most common rhythm changes in taiko maps.
+        /// </summary>
+        /// <remarks>
+        /// The general guidelines for the values are:
+        /// <list type="bullet">
+        /// <item>rhythm changes with ratio closer to 1 (that are <i>not</i> 1) are harder to play,</item>
+        /// <item>speeding up is <i>generally</i> harder than slowing down (with exceptions of rhythm changes requiring a hand switch).</item>
+        /// </list>
+        /// </remarks>
+        private static readonly TaikoDifficultyHitObjectRhythm[] common_rhythms =
+        {
+            new TaikoDifficultyHitObjectRhythm(1, 1, 0.0),
+            new TaikoDifficultyHitObjectRhythm(2, 1, 0.3),
+            new TaikoDifficultyHitObjectRhythm(1, 2, 0.5),
+            new TaikoDifficultyHitObjectRhythm(3, 1, 0.3),
+            new TaikoDifficultyHitObjectRhythm(1, 3, 0.35),
+            new TaikoDifficultyHitObjectRhythm(3, 2, 0.6), // purposefully higher (requires hand switch in full alternating gameplay style)
+            new TaikoDifficultyHitObjectRhythm(2, 3, 0.4),
+            new TaikoDifficultyHitObjectRhythm(5, 4, 0.5),
+            new TaikoDifficultyHitObjectRhythm(4, 5, 0.7)
+        };
+
+        /// <summary>
+        /// Returns the closest rhythm change from <see cref="common_rhythms"/> required to hit this object.
+        /// </summary>
+        /// <param name="lastObject">The gameplay <see cref="HitObject"/> preceding this one.</param>
+        /// <param name="lastLastObject">The gameplay <see cref="HitObject"/> preceding <paramref name="lastObject"/>.</param>
+        private TaikoDifficultyHitObjectRhythm getClosestRhythm(HitObject lastObject, HitObject lastLastObject)
+        {
+            double prevLength = (lastObject.time - lastLastObject.time);
+            double ratio = DeltaTime / prevLength;
+
+            return common_rhythms.OrderBy(x => Math.Abs(x.Ratio - ratio)).First();
+        }
+
+        public TaikoDifficultyHitObject? PreviousMono(int backwardsIndex) => monoDifficultyHitObjects?.ElementAtOrDefault(MonoIndex - (backwardsIndex + 1));
+
+        public TaikoDifficultyHitObject? NextMono(int forwardsIndex) => monoDifficultyHitObjects?.ElementAtOrDefault(MonoIndex + (forwardsIndex + 1));
+
+        public TaikoDifficultyHitObject? PreviousNote(int backwardsIndex) => noteDifficultyHitObjects.ElementAtOrDefault(NoteIndex - (backwardsIndex + 1));
+
+        public TaikoDifficultyHitObject? NextNote(int forwardsIndex) => noteDifficultyHitObjects.ElementAtOrDefault(NoteIndex + (forwardsIndex + 1));
+    }
+}

--- a/starrating/taiko/preprocessing/colour/TaikoColourDifficultyPreprocessor.cs
+++ b/starrating/taiko/preprocessing/colour/TaikoColourDifficultyPreprocessor.cs
@@ -1,0 +1,168 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using MapsetParser.objects.taiko;
+using MapsetParser.starrating.preprocessing;
+using MapsetParser.starrating.taiko.preprocessing.Colour.Data;
+
+namespace MapsetParser.starrating.taiko.preprocessing.Colour
+{
+    /// <summary>
+    /// Utility class to perform various encodings.
+    /// </summary>
+    public static class TaikoColourDifficultyPreprocessor
+    {
+        /// <summary>
+        /// Processes and encodes a list of <see cref="TaikoDifficultyHitObject"/>s into a list of <see cref="TaikoDifficultyHitObjectColour"/>s,
+        /// assigning the appropriate <see cref="TaikoDifficultyHitObjectColour"/>s to each <see cref="TaikoDifficultyHitObject"/>.
+        /// </summary>
+        public static void ProcessAndAssign(List<DifficultyHitObject> hitObjects)
+        {
+            List<RepeatingHitPatterns> hitPatterns = encode(hitObjects);
+
+            // Assign indexing and encoding data to all relevant objects.
+            foreach (var repeatingHitPattern in hitPatterns)
+            {
+                // The outermost loop is kept a ForEach loop since it doesn't need index information, and we want to
+                // keep i and j for AlternatingMonoPattern's and MonoStreak's index respectively, to keep it in line with
+                // documentation.
+                for (int i = 0; i < repeatingHitPattern.AlternatingMonoPatterns.Count; ++i)
+                {
+                    AlternatingMonoPattern monoPattern = repeatingHitPattern.AlternatingMonoPatterns[i];
+                    monoPattern.Parent = repeatingHitPattern;
+                    monoPattern.Index = i;
+
+                    for (int j = 0; j < monoPattern.MonoStreaks.Count; ++j)
+                    {
+                        MonoStreak monoStreak = monoPattern.MonoStreaks[j];
+                        monoStreak.Parent = monoPattern;
+                        monoStreak.Index = j;
+
+                        foreach (var hitObject in monoStreak.HitObjects)
+                        {
+                            hitObject.Colour.RepeatingHitPattern = repeatingHitPattern;
+                            hitObject.Colour.AlternatingMonoPattern = monoPattern;
+                            hitObject.Colour.MonoStreak = monoStreak;
+                        }
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Encodes a list of <see cref="TaikoDifficultyHitObject"/>s into a list of <see cref="RepeatingHitPatterns"/>s.
+        /// </summary>
+        private static List<RepeatingHitPatterns> encode(List<DifficultyHitObject> data)
+        {
+            List<MonoStreak> monoStreaks = encodeMonoStreak(data);
+            List<AlternatingMonoPattern> alternatingMonoPatterns = encodeAlternatingMonoPattern(monoStreaks);
+            List<RepeatingHitPatterns> repeatingHitPatterns = encodeRepeatingHitPattern(alternatingMonoPatterns);
+
+            return repeatingHitPatterns;
+        }
+
+        /// <summary>
+        /// Encodes a list of <see cref="TaikoDifficultyHitObject"/>s into a list of <see cref="MonoStreak"/>s.
+        /// </summary>
+        private static List<MonoStreak> encodeMonoStreak(List<DifficultyHitObject> data)
+        {
+            List<MonoStreak> monoStreaks = new List<MonoStreak>();
+            MonoStreak? currentMonoStreak = null;
+
+            for (int i = 0; i < data.Count; i++)
+            {
+                TaikoDifficultyHitObject taikoObject = (TaikoDifficultyHitObject)data[i];
+
+                // This ignores all non-note objects, which may or may not be the desired behaviour
+                TaikoDifficultyHitObject? previousObject = taikoObject.PreviousNote(0);
+
+                // If this is the first object in the list or the colour changed, create a new mono streak
+                if (currentMonoStreak == null || previousObject == null || (taikoObject.BaseObject as Hit)?.Type != (previousObject.BaseObject as Hit)?.Type)
+                {
+                    currentMonoStreak = new MonoStreak();
+                    monoStreaks.Add(currentMonoStreak);
+                }
+
+                // Add the current object to the encoded payload.
+                currentMonoStreak.HitObjects.Add(taikoObject);
+            }
+
+            return monoStreaks;
+        }
+
+        /// <summary>
+        /// Encodes a list of <see cref="MonoStreak"/>s into a list of <see cref="AlternatingMonoPattern"/>s.
+        /// </summary>
+        private static List<AlternatingMonoPattern> encodeAlternatingMonoPattern(List<MonoStreak> data)
+        {
+            List<AlternatingMonoPattern> monoPatterns = new List<AlternatingMonoPattern>();
+            AlternatingMonoPattern? currentMonoPattern = null;
+
+            for (int i = 0; i < data.Count; i++)
+            {
+                // Start a new AlternatingMonoPattern if the previous MonoStreak has a different mono length, or if this is the first MonoStreak in the list.
+                if (currentMonoPattern == null || data[i].RunLength != data[i - 1].RunLength)
+                {
+                    currentMonoPattern = new AlternatingMonoPattern();
+                    monoPatterns.Add(currentMonoPattern);
+                }
+
+                // Add the current MonoStreak to the encoded payload.
+                currentMonoPattern.MonoStreaks.Add(data[i]);
+            }
+
+            return monoPatterns;
+        }
+
+        /// <summary>
+        /// Encodes a list of <see cref="AlternatingMonoPattern"/>s into a list of <see cref="RepeatingHitPatterns"/>s.
+        /// </summary>
+        private static List<RepeatingHitPatterns> encodeRepeatingHitPattern(List<AlternatingMonoPattern> data)
+        {
+            List<RepeatingHitPatterns> hitPatterns = new List<RepeatingHitPatterns>();
+            RepeatingHitPatterns? currentHitPattern = null;
+
+            for (int i = 0; i < data.Count; i++)
+            {
+                // Start a new RepeatingHitPattern. AlternatingMonoPatterns that should be grouped together will be handled later within this loop.
+                currentHitPattern = new RepeatingHitPatterns(currentHitPattern);
+
+                // Determine if future AlternatingMonoPatterns should be grouped.
+                bool isCoupled = i < data.Count - 2 && data[i].IsRepetitionOf(data[i + 2]);
+
+                if (!isCoupled)
+                {
+                    // If not, add the current AlternatingMonoPattern to the encoded payload and continue.
+                    currentHitPattern.AlternatingMonoPatterns.Add(data[i]);
+                }
+                else
+                {
+                    // If so, add the current AlternatingMonoPattern to the encoded payload and start repeatedly checking if the
+                    // subsequent AlternatingMonoPatterns should be grouped by increasing i and doing the appropriate isCoupled check.
+                    while (isCoupled)
+                    {
+                        currentHitPattern.AlternatingMonoPatterns.Add(data[i]);
+                        i++;
+                        isCoupled = i < data.Count - 2 && data[i].IsRepetitionOf(data[i + 2]);
+                    }
+
+                    // Skip over viewed data and add the rest to the payload
+                    currentHitPattern.AlternatingMonoPatterns.Add(data[i]);
+                    currentHitPattern.AlternatingMonoPatterns.Add(data[i + 1]);
+                    i++;
+                }
+
+                hitPatterns.Add(currentHitPattern);
+            }
+
+            // Final pass to find repetition intervals
+            for (int i = 0; i < hitPatterns.Count; i++)
+            {
+                hitPatterns[i].FindRepetitionInterval();
+            }
+
+            return hitPatterns;
+        }
+    }
+}

--- a/starrating/taiko/preprocessing/colour/TaikoDifficultyHitObjectColour.cs
+++ b/starrating/taiko/preprocessing/colour/TaikoDifficultyHitObjectColour.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using MapsetParser.starrating.taiko.preprocessing.Colour.Data;
+
+namespace MapsetParser.starrating.taiko.preprocessing.Colour
+{
+    /// <summary>
+    /// Stores colour compression information for a <see cref="TaikoDifficultyHitObject"/>.
+    /// </summary>
+    public class TaikoDifficultyHitObjectColour
+    {
+        /// <summary>
+        /// The <see cref="MonoStreak"/> that encodes this note.
+        /// </summary>
+        public MonoStreak? MonoStreak;
+
+        /// <summary>
+        /// The <see cref="AlternatingMonoPattern"/> that encodes this note.
+        /// </summary>
+        public AlternatingMonoPattern? AlternatingMonoPattern;
+
+        /// <summary>
+        /// The <see cref="RepeatingHitPattern"/> that encodes this note.
+        /// </summary>
+        public RepeatingHitPatterns? RepeatingHitPattern;
+
+        /// <summary>
+        /// The closest past <see cref="TaikoDifficultyHitObject"/> that's not the same colour.
+        /// </summary>
+        public TaikoDifficultyHitObject? PreviousColourChange => MonoStreak?.FirstHitObject.PreviousNote(0);
+
+        /// <summary>
+        /// The closest future <see cref="TaikoDifficultyHitObject"/> that's not the same colour.
+        /// </summary>
+        public TaikoDifficultyHitObject? NextColourChange => MonoStreak?.LastHitObject.NextNote(0);
+    }
+}

--- a/starrating/taiko/preprocessing/colour/data/AlternatingMonoPattern.cs
+++ b/starrating/taiko/preprocessing/colour/data/AlternatingMonoPattern.cs
@@ -1,0 +1,53 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+
+namespace MapsetParser.starrating.taiko.preprocessing.Colour.Data
+{
+    /// <summary>
+    /// Encodes a list of <see cref="MonoStreak"/>s.
+    /// <see cref="MonoStreak"/>s with the same <see cref="MonoStreak.RunLength"/> are grouped together.
+    /// </summary>
+    public class AlternatingMonoPattern
+    {
+        /// <summary>
+        /// <see cref="MonoStreak"/>s that are grouped together within this <see cref="AlternatingMonoPattern"/>.
+        /// </summary>
+        public readonly List<MonoStreak> MonoStreaks = new List<MonoStreak>();
+
+        /// <summary>
+        /// The parent <see cref="RepeatingHitPatterns"/> that contains this <see cref="AlternatingMonoPattern"/>
+        /// </summary>
+        public RepeatingHitPatterns Parent = null!;
+
+        /// <summary>
+        /// Index of this <see cref="AlternatingMonoPattern"/> within it's parent <see cref="RepeatingHitPatterns"/>
+        /// </summary>
+        public int Index;
+
+        /// <summary>
+        /// The first <see cref="TaikoDifficultyHitObject"/> in this <see cref="AlternatingMonoPattern"/>.
+        /// </summary>
+        public TaikoDifficultyHitObject FirstHitObject => MonoStreaks[0].FirstHitObject;
+
+        /// <summary>
+        /// Determine if this <see cref="AlternatingMonoPattern"/> is a repetition of another <see cref="AlternatingMonoPattern"/>. This
+        /// is a strict comparison and is true if and only if the colour sequence is exactly the same.
+        /// </summary>
+        public bool IsRepetitionOf(AlternatingMonoPattern other)
+        {
+            return HasIdenticalMonoLength(other) &&
+                   other.MonoStreaks.Count == MonoStreaks.Count &&
+                   other.MonoStreaks[0].HitType == MonoStreaks[0].HitType;
+        }
+
+        /// <summary>
+        /// Determine if this <see cref="AlternatingMonoPattern"/> has the same mono length of another <see cref="AlternatingMonoPattern"/>.
+        /// </summary>
+        public bool HasIdenticalMonoLength(AlternatingMonoPattern other)
+        {
+            return other.MonoStreaks[0].RunLength == MonoStreaks[0].RunLength;
+        }
+    }
+}

--- a/starrating/taiko/preprocessing/colour/data/MonoStreak.cs
+++ b/starrating/taiko/preprocessing/colour/data/MonoStreak.cs
@@ -1,0 +1,50 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using MapsetParser.objects.taiko;
+
+namespace MapsetParser.starrating.taiko.preprocessing.Colour.Data
+{
+    /// <summary>
+    /// Encode colour information for a sequence of <see cref="TaikoDifficultyHitObject"/>s. Consecutive <see cref="TaikoDifficultyHitObject"/>s
+    /// of the same <see cref="Objects.HitType"/> are encoded within the same <see cref="MonoStreak"/>.
+    /// </summary>
+    public class MonoStreak
+    {
+        /// <summary>
+        /// List of <see cref="DifficultyHitObject"/>s that are encoded within this <see cref="MonoStreak"/>.
+        /// </summary>
+        public List<TaikoDifficultyHitObject> HitObjects { get; private set; } = new List<TaikoDifficultyHitObject>();
+
+        /// <summary>
+        /// The parent <see cref="AlternatingMonoPattern"/> that contains this <see cref="MonoStreak"/>
+        /// </summary>
+        public AlternatingMonoPattern Parent = null!;
+
+        /// <summary>
+        /// Index of this <see cref="MonoStreak"/> within it's parent <see cref="AlternatingMonoPattern"/>
+        /// </summary>
+        public int Index;
+
+        /// <summary>
+        /// The first <see cref="TaikoDifficultyHitObject"/> in this <see cref="MonoStreak"/>.
+        /// </summary>
+        public TaikoDifficultyHitObject FirstHitObject => HitObjects[0];
+
+        /// <summary>
+        /// The last <see cref="TaikoDifficultyHitObject"/> in this <see cref="MonoStreak"/>.
+        /// </summary>
+        public TaikoDifficultyHitObject LastHitObject => HitObjects[^1];
+
+        /// <summary>
+        /// The hit type of all objects encoded within this <see cref="MonoStreak"/>
+        /// </summary>
+        public HitType? HitType => (HitObjects[0].BaseObject as Hit)?.Type;
+
+        /// <summary>
+        /// How long the mono pattern encoded within is
+        /// </summary>
+        public int RunLength => HitObjects.Count;
+    }
+}

--- a/starrating/taiko/preprocessing/colour/data/RepeatingHitPatterns.cs
+++ b/starrating/taiko/preprocessing/colour/data/RepeatingHitPatterns.cs
@@ -1,0 +1,94 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+
+namespace MapsetParser.starrating.taiko.preprocessing.Colour.Data
+{
+    /// <summary>
+    /// Encodes a list of <see cref="AlternatingMonoPattern"/>s, grouped together by back and forth repetition of the same
+    /// <see cref="AlternatingMonoPattern"/>. Also stores the repetition interval between this and the previous <see cref="RepeatingHitPatterns"/>.
+    /// </summary>
+    public class RepeatingHitPatterns
+    {
+        /// <summary>
+        /// Maximum amount of <see cref="RepeatingHitPatterns"/>s to look back to find a repetition.
+        /// </summary>
+        private const int max_repetition_interval = 16;
+
+        /// <summary>
+        /// The <see cref="AlternatingMonoPattern"/>s that are grouped together within this <see cref="RepeatingHitPatterns"/>.
+        /// </summary>
+        public readonly List<AlternatingMonoPattern> AlternatingMonoPatterns = new List<AlternatingMonoPattern>();
+
+        /// <summary>
+        /// The first <see cref="TaikoDifficultyHitObject"/> in this <see cref="RepeatingHitPatterns"/>
+        /// </summary>
+        public TaikoDifficultyHitObject FirstHitObject => AlternatingMonoPatterns[0].FirstHitObject;
+
+        /// <summary>
+        /// The previous <see cref="RepeatingHitPatterns"/>. This is used to determine the repetition interval.
+        /// </summary>
+        public readonly RepeatingHitPatterns? Previous;
+
+        /// <summary>
+        /// How many <see cref="RepeatingHitPatterns"/> between the current and previous identical <see cref="RepeatingHitPatterns"/>.
+        /// If no repetition is found this will have a value of <see cref="max_repetition_interval"/> + 1.
+        /// </summary>
+        public int RepetitionInterval { get; private set; } = max_repetition_interval + 1;
+
+        public RepeatingHitPatterns(RepeatingHitPatterns? previous)
+        {
+            Previous = previous;
+        }
+
+        /// <summary>
+        /// Returns true if other is considered a repetition of this pattern. This is true if other's first two payloads
+        /// have identical mono lengths.
+        /// </summary>
+        private bool isRepetitionOf(RepeatingHitPatterns other)
+        {
+            if (AlternatingMonoPatterns.Count != other.AlternatingMonoPatterns.Count) return false;
+
+            for (int i = 0; i < Math.Min(AlternatingMonoPatterns.Count, 2); i++)
+            {
+                if (!AlternatingMonoPatterns[i].HasIdenticalMonoLength(other.AlternatingMonoPatterns[i])) return false;
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Finds the closest previous <see cref="RepeatingHitPatterns"/> that has the identical <see cref="AlternatingMonoPatterns"/>.
+        /// Interval is defined as the amount of <see cref="RepeatingHitPatterns"/> chunks between the current and repeated patterns.
+        /// </summary>
+        public void FindRepetitionInterval()
+        {
+            if (Previous == null)
+            {
+                RepetitionInterval = max_repetition_interval + 1;
+                return;
+            }
+
+            RepeatingHitPatterns? other = Previous;
+            int interval = 1;
+
+            while (interval < max_repetition_interval)
+            {
+                if (isRepetitionOf(other))
+                {
+                    RepetitionInterval = Math.Min(interval, max_repetition_interval);
+                    return;
+                }
+
+                other = other.Previous;
+                if (other == null) break;
+
+                ++interval;
+            }
+
+            RepetitionInterval = max_repetition_interval + 1;
+        }
+    }
+}

--- a/starrating/taiko/preprocessing/rhythm/TaikoDifficultyHitObjectRhythm.cs
+++ b/starrating/taiko/preprocessing/rhythm/TaikoDifficultyHitObjectRhythm.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace MapsetParser.starrating.taiko.preprocessing.Rhythm
+{
+    /// <summary>
+    /// Represents a rhythm change in a taiko map.
+    /// </summary>
+    public class TaikoDifficultyHitObjectRhythm
+    {
+        /// <summary>
+        /// The difficulty multiplier associated with this rhythm change.
+        /// </summary>
+        public readonly double Difficulty;
+
+        /// <summary>
+        /// The ratio of current <see cref="osu.Game.Rulesets.Difficulty.Preprocessing.DifficultyHitObject.DeltaTime"/>
+        /// to previous <see cref="osu.Game.Rulesets.Difficulty.Preprocessing.DifficultyHitObject.DeltaTime"/> for the rhythm change.
+        /// A <see cref="Ratio"/> above 1 indicates a slow-down; a <see cref="Ratio"/> below 1 indicates a speed-up.
+        /// </summary>
+        public readonly double Ratio;
+
+        /// <summary>
+        /// Creates an object representing a rhythm change.
+        /// </summary>
+        /// <param name="numerator">The numerator for <see cref="Ratio"/>.</param>
+        /// <param name="denominator">The denominator for <see cref="Ratio"/></param>
+        /// <param name="difficulty">The difficulty multiplier associated with this rhythm change.</param>
+        public TaikoDifficultyHitObjectRhythm(int numerator, int denominator, double difficulty)
+        {
+            Ratio = numerator / (double)denominator;
+            Difficulty = difficulty;
+        }
+    }
+}

--- a/starrating/taiko/scoring/TaikoHitWindows.cs
+++ b/starrating/taiko/scoring/TaikoHitWindows.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using MapsetParser.scoring;
+
+namespace MapsetParser.starrating.taiko.scoring
+{
+    public class TaikoHitWindows : HitWindows
+    {
+        private static readonly DifficultyRange[] taiko_ranges =
+        {
+            new DifficultyRange(HitResult.Great, 50, 35, 20),
+            new DifficultyRange(HitResult.Ok, 120, 80, 50),
+            new DifficultyRange(HitResult.Miss, 135, 95, 70),
+        };
+
+        public override bool IsHitResultAllowed(HitResult result)
+        {
+            switch (result)
+            {
+                case HitResult.Great:
+                case HitResult.Ok:
+                case HitResult.Miss:
+                    return true;
+            }
+
+            return false;
+        }
+
+        protected override DifficultyRange[] GetRanges() => taiko_ranges;
+    }
+}

--- a/starrating/taiko/skills/Colour.cs
+++ b/starrating/taiko/skills/Colour.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using MapsetParser.starrating.preprocessing;
+using MapsetParser.starrating.skills;
+using MapsetParser.starrating.taiko.evaluators;
+
+namespace MapsetParser.starrating.taiko.skills
+{
+    /// <summary>
+    /// Calculates the colour coefficient of taiko difficulty.
+    /// </summary>
+    public class Colour : StrainDecaySkill
+    {
+        protected override double SkillMultiplier => 0.12;
+
+        // This is set to decay slower than other skills, due to the fact that only the first note of each encoding class
+        //  having any difficulty values, and we want to allow colour difficulty to be able to build up even on
+        // slower maps.
+        protected override double StrainDecayBase => 0.8;
+
+        public override string SkillName() => "Colour";
+
+        public Colour()
+            : base()
+        {
+        }
+
+        protected override double StrainValueOf(DifficultyHitObject current)
+        {
+            return ColourEvaluator.EvaluateDifficultyOf(current);
+        }
+    }
+}

--- a/starrating/taiko/skills/Peaks.cs
+++ b/starrating/taiko/skills/Peaks.cs
@@ -1,0 +1,94 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using MapsetParser.starrating.preprocessing;
+using MapsetParser.starrating.skills;
+
+namespace MapsetParser.starrating.taiko.skills
+{
+    public class Peaks : Skill
+    {
+        private const double rhythm_skill_multiplier = 0.2 * final_multiplier;
+        private const double colour_skill_multiplier = 0.375 * final_multiplier;
+        private const double stamina_skill_multiplier = 0.375 * final_multiplier;
+
+        private const double final_multiplier = 0.0625;
+
+        private readonly Rhythm rhythm;
+        private readonly Colour colour;
+        private readonly Stamina stamina;
+
+        public double ColourDifficultyValue => colour.DifficultyValue() * colour_skill_multiplier;
+        public double RhythmDifficultyValue => rhythm.DifficultyValue() * rhythm_skill_multiplier;
+        public double StaminaDifficultyValue => stamina.DifficultyValue() * stamina_skill_multiplier;
+
+        public override string SkillName() => "Peaks";
+
+        public Peaks()
+            : base()
+        {
+            rhythm = new Rhythm();
+            colour = new Colour();
+            stamina = new Stamina();
+        }
+
+        /// <summary>
+        /// Returns the <i>p</i>-norm of an <i>n</i>-dimensional vector.
+        /// </summary>
+        /// <param name="p">The value of <i>p</i> to calculate the norm for.</param>
+        /// <param name="values">The coefficients of the vector.</param>
+        private double norm(double p, params double[] values) => Math.Pow(values.Sum(x => Math.Pow(x, p)), 1 / p);
+
+        public override void Process(DifficultyHitObject current)
+        {
+            rhythm.Process(current);
+            colour.Process(current);
+            stamina.Process(current);
+        }
+
+        /// <summary>
+        /// Returns the combined star rating of the beatmap, calculated using peak strains from all sections of the map.
+        /// </summary>
+        /// <remarks>
+        /// For each section, the peak strains of all separate skills are combined into a single peak strain for the section.
+        /// The resulting partial rating of the beatmap is a weighted sum of the combined peaks (higher peaks are weighted more).
+        /// </remarks>
+        public override double DifficultyValue()
+        {
+            List<double> peaks = new List<double>();
+
+            var colourPeaks = colour.GetCurrentStrainPeaks().ToList();
+            var rhythmPeaks = rhythm.GetCurrentStrainPeaks().ToList();
+            var staminaPeaks = stamina.GetCurrentStrainPeaks().ToList();
+
+            for (int i = 0; i < colourPeaks.Count; i++)
+            {
+                double colourPeak = colourPeaks[i] * colour_skill_multiplier;
+                double rhythmPeak = rhythmPeaks[i] * rhythm_skill_multiplier;
+                double staminaPeak = staminaPeaks[i] * stamina_skill_multiplier;
+
+                double peak = norm(1.5, colourPeak, staminaPeak);
+                peak = norm(2, peak, rhythmPeak);
+
+                // Sections with 0 strain are excluded to avoid worst-case time complexity of the following sort (e.g. /b/2351871).
+                // These sections will not contribute to the difficulty.
+                if (peak > 0)
+                    peaks.Add(peak);
+            }
+
+            double difficulty = 0;
+            double weight = 1;
+
+            foreach (double strain in peaks.OrderByDescending(d => d))
+            {
+                difficulty += strain * weight;
+                weight *= 0.9;
+            }
+
+            return difficulty;
+        }
+    }
+}

--- a/starrating/taiko/skills/Rhythm.cs
+++ b/starrating/taiko/skills/Rhythm.cs
@@ -1,0 +1,174 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using MapsetParser.objects.taiko;
+using MapsetParser.starrating.preprocessing;
+using MapsetParser.starrating.skills;
+using MapsetParser.starrating.taiko.preprocessing;
+using MapsetParser.starrating.utils;
+
+namespace MapsetParser.starrating.taiko.skills
+{
+    /// <summary>
+    /// Calculates the rhythm coefficient of taiko difficulty.
+    /// </summary>
+    public class Rhythm : StrainDecaySkill
+    {
+        protected override double SkillMultiplier => 10;
+        protected override double StrainDecayBase => 0;
+
+        /// <summary>
+        /// The note-based decay for rhythm strain.
+        /// </summary>
+        /// <remarks>
+        /// <see cref="StrainDecayBase"/> is not used here, as it's time- and not note-based.
+        /// </remarks>
+        private const double strain_decay = 0.96;
+
+        /// <summary>
+        /// Maximum number of entries in <see cref="rhythmHistory"/>.
+        /// </summary>
+        private const int rhythm_history_max_length = 8;
+
+        /// <summary>
+        /// Contains the last <see cref="rhythm_history_max_length"/> changes in note sequence rhythms.
+        /// </summary>
+        private readonly LimitedCapacityQueue<TaikoDifficultyHitObject> rhythmHistory = new LimitedCapacityQueue<TaikoDifficultyHitObject>(rhythm_history_max_length);
+
+        /// <summary>
+        /// Contains the rolling rhythm strain.
+        /// Used to apply per-note decay.
+        /// </summary>
+        private double currentStrain;
+
+        /// <summary>
+        /// Number of notes since the last rhythm change has taken place.
+        /// </summary>
+        private int notesSinceRhythmChange;
+
+        public override string SkillName() => "Rhythm";
+
+        public Rhythm()
+            : base()
+        {
+        }
+
+        protected override double StrainValueOf(DifficultyHitObject current)
+        {
+            // drum rolls and swells are exempt.
+            if (!(current.BaseObject is Hit))
+            {
+                resetRhythmAndStrain();
+                return 0.0;
+            }
+
+            currentStrain *= strain_decay;
+
+            TaikoDifficultyHitObject hitObject = (TaikoDifficultyHitObject)current;
+            notesSinceRhythmChange += 1;
+
+            // rhythm difficulty zero (due to rhythm not changing) => no rhythm strain.
+            if (hitObject.Rhythm.Difficulty == 0.0)
+            {
+                return 0.0;
+            }
+
+            double objectStrain = hitObject.Rhythm.Difficulty;
+
+            objectStrain *= repetitionPenalties(hitObject);
+            objectStrain *= patternLengthPenalty(notesSinceRhythmChange);
+            objectStrain *= speedPenalty(hitObject.DeltaTime);
+
+            // careful - needs to be done here since calls above read this value
+            notesSinceRhythmChange = 0;
+
+            currentStrain += objectStrain;
+            return currentStrain;
+        }
+
+        /// <summary>
+        /// Returns a penalty to apply to the current hit object caused by repeating rhythm changes.
+        /// </summary>
+        /// <remarks>
+        /// Repetitions of more recent patterns are associated with a higher penalty.
+        /// </remarks>
+        /// <param name="hitObject">The current hit object being considered.</param>
+        private double repetitionPenalties(TaikoDifficultyHitObject hitObject)
+        {
+            double penalty = 1;
+
+            rhythmHistory.Enqueue(hitObject);
+
+            for (int mostRecentPatternsToCompare = 2; mostRecentPatternsToCompare <= rhythm_history_max_length / 2; mostRecentPatternsToCompare++)
+            {
+                for (int start = rhythmHistory.Count - mostRecentPatternsToCompare - 1; start >= 0; start--)
+                {
+                    if (!samePattern(start, mostRecentPatternsToCompare))
+                        continue;
+
+                    int notesSince = hitObject.Index - rhythmHistory[start].Index;
+                    penalty *= repetitionPenalty(notesSince);
+                    break;
+                }
+            }
+
+            return penalty;
+        }
+
+        /// <summary>
+        /// Determines whether the rhythm change pattern starting at <paramref name="start"/> is a repeat of any of the
+        /// <paramref name="mostRecentPatternsToCompare"/>.
+        /// </summary>
+        private bool samePattern(int start, int mostRecentPatternsToCompare)
+        {
+            for (int i = 0; i < mostRecentPatternsToCompare; i++)
+            {
+                if (rhythmHistory[start + i].Rhythm != rhythmHistory[rhythmHistory.Count - mostRecentPatternsToCompare + i].Rhythm)
+                    return false;
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Calculates a single rhythm repetition penalty.
+        /// </summary>
+        /// <param name="notesSince">Number of notes since the last repetition of a rhythm change.</param>
+        private static double repetitionPenalty(int notesSince) => Math.Min(1.0, 0.032 * notesSince);
+
+        /// <summary>
+        /// Calculates a penalty based on the number of notes since the last rhythm change.
+        /// Both rare and frequent rhythm changes are penalised.
+        /// </summary>
+        /// <param name="patternLength">Number of notes since the last rhythm change.</param>
+        private static double patternLengthPenalty(int patternLength)
+        {
+            double shortPatternPenalty = Math.Min(0.15 * patternLength, 1.0);
+            double longPatternPenalty = Math.Clamp(2.5 - 0.15 * patternLength, 0.0, 1.0);
+            return Math.Min(shortPatternPenalty, longPatternPenalty);
+        }
+
+        /// <summary>
+        /// Calculates a penalty for objects that do not require alternating hands.
+        /// </summary>
+        /// <param name="deltaTime">Time (in milliseconds) since the last hit object.</param>
+        private double speedPenalty(double deltaTime)
+        {
+            if (deltaTime < 80) return 1;
+            if (deltaTime < 210) return Math.Max(0, 1.4 - 0.005 * deltaTime);
+
+            resetRhythmAndStrain();
+            return 0.0;
+        }
+
+        /// <summary>
+        /// Resets the rolling strain value and <see cref="notesSinceRhythmChange"/> counter.
+        /// </summary>
+        private void resetRhythmAndStrain()
+        {
+            currentStrain = 0.0;
+            notesSinceRhythmChange = 0;
+        }
+    }
+}

--- a/starrating/taiko/skills/Stamina.cs
+++ b/starrating/taiko/skills/Stamina.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using MapsetParser.starrating.preprocessing;
+using MapsetParser.starrating.skills;
+using MapsetParser.starrating.taiko.evaluators;
+
+namespace MapsetParser.starrating.taiko.skills
+{
+    /// <summary>
+    /// Calculates the stamina coefficient of taiko difficulty.
+    /// </summary>
+    public class Stamina : StrainDecaySkill
+    {
+        protected override double SkillMultiplier => 1.1;
+        protected override double StrainDecayBase => 0.4;
+
+        public override string SkillName() => "Stamina";
+
+        /// <summary>
+        /// Creates a <see cref="Stamina"/> skill.
+        /// </summary>
+        /// <param name="mods">Mods for use in skill calculations.</param>
+        public Stamina()
+            : base()
+        {
+        }
+
+        protected override double StrainValueOf(DifficultyHitObject current)
+        {
+            return StaminaEvaluator.EvaluateDifficultyOf(current);
+        }
+    }
+}

--- a/starrating/utils/LimitedCapacityQueue.cs
+++ b/starrating/utils/LimitedCapacityQueue.cs
@@ -1,0 +1,123 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace MapsetParser.starrating.utils
+{
+    /// <summary>
+    /// An indexed queue with limited capacity.
+    /// Respects first-in-first-out insertion order.
+    /// </summary>
+    public class LimitedCapacityQueue<T> : IEnumerable<T>
+    {
+        /// <summary>
+        /// The number of elements in the queue.
+        /// </summary>
+        public int Count { get; private set; }
+
+        /// <summary>
+        /// Whether the queue is full (adding any new items will cause removing existing ones).
+        /// </summary>
+        public bool Full => Count == capacity;
+
+        private readonly T[] array;
+        private readonly int capacity;
+
+        // Markers tracking the queue's first and last element.
+        private int start, end;
+
+        /// <summary>
+        /// Constructs a new <see cref="LimitedCapacityQueue{T}"/>
+        /// </summary>
+        /// <param name="capacity">The number of items the queue can hold.</param>
+        public LimitedCapacityQueue(int capacity)
+        {
+            if (capacity < 0)
+                throw new ArgumentOutOfRangeException(nameof(capacity));
+
+            this.capacity = capacity;
+            array = new T[capacity];
+            Clear();
+        }
+
+        /// <summary>
+        /// Removes all elements from the <see cref="LimitedCapacityQueue{T}"/>.
+        /// </summary>
+        public void Clear()
+        {
+            start = 0;
+            end = -1;
+            Count = 0;
+        }
+
+        /// <summary>
+        /// Removes an item from the front of the <see cref="LimitedCapacityQueue{T}"/>.
+        /// </summary>
+        /// <returns>The item removed from the front of the queue.</returns>
+        public T Dequeue()
+        {
+            if (Count == 0)
+                throw new InvalidOperationException("Queue is empty.");
+
+            var result = array[start];
+            start = (start + 1) % capacity;
+            Count--;
+            return result;
+        }
+
+        /// <summary>
+        /// Adds an item to the back of the <see cref="LimitedCapacityQueue{T}"/>.
+        /// If the queue is holding <see cref="Count"/> elements at the point of addition,
+        /// the item at the front of the queue will be removed.
+        /// </summary>
+        /// <param name="item">The item to be added to the back of the queue.</param>
+        public void Enqueue(T item)
+        {
+            end = (end + 1) % capacity;
+            if (Count == capacity)
+                start = (start + 1) % capacity;
+            else
+                Count++;
+            array[end] = item;
+        }
+
+        /// <summary>
+        /// Retrieves the item at the given index in the queue.
+        /// </summary>
+        /// <param name="index">
+        /// The index of the item to retrieve.
+        /// The item with index 0 is at the front of the queue
+        /// (it was added the earliest).
+        /// </param>
+        public T this[int index]
+        {
+            get
+            {
+                if (index < 0 || index >= Count)
+                    throw new ArgumentOutOfRangeException(nameof(index));
+
+                return array[(start + index) % capacity];
+            }
+        }
+
+        /// <summary>
+        /// Enumerates the queue from its start to its end.
+        /// </summary>
+        public IEnumerator<T> GetEnumerator()
+        {
+            if (Count == 0)
+                yield break;
+
+            for (int i = 0; i < Count; i++)
+                yield return array[(start + i) % capacity];
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
This PR implements the Taiko Difficulty Calculator for SR calculation.

This is pretty useful, since recently [a Taiko MV plugin](https://github.com/Hiviexd/MVTaikoChecks) has now been released and frequently used by mappers/modders. And since SR calc is not implemented, all star ratings are 0.00*, which makes any diff with a custom name default to an "Easy" (Kantan in taiko). (reference: https://github.com/Hiviexd/MVTaikoChecks/issues/6)

As far as approach taken, I aimed to port [the osu!lazer diff calc](https://github.com/ppy/osu/blob/master/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyCalculator.cs) while making as few changes to the original source as possible. I also tried to keep the existing `MapsetParser` code as intact as possible.

However, I will discuss the parts I did have to change.

## MapsetParser Classes which differ from their original implementation
* `Skill` was originally basically a superclass which handled strain/decay. In Lazer implementation, `Skill` is much more abstract and generic, and there are separate `StrainSkill` and `StrainDecaySkill` subclasses instead.
  * I basically changed this to be more like the lazer implementation, trying to keep it as close to lazer source as possible
  * `Skill` also previously tracked the "previous" hit object from the current one being calculated. In lazer, this is now tracked within `DifficultyHitObject` so I removed this from `Skill`
  * Other classes have been modified slightly to accomodate these changes, including `Aim`, `Speed`, and `DifficultyCalculator`
* `DifficultyHitObject` now has members/methods to track Next and Previous objects, Index, and StartTime and EndTimes
* `Beatmap` is modified to use the `TaikoDifficultyCalculator` when taiko mode is detected
  * The parsing was also changed if the game mode is taiko, so that it will use the new `Hit` class instead of `Circle`
  
 ## Lazer classes which differ from their lazer implementation
 * All classes using `clockrate` or mods have had that removed, since it's not really relevant for MV purposes
 * Any stuff with serialization was also removed
 * `Hit` is quite different from the lazer implementation. In my implementation it's basically similar to a `Circle` but it will figure out if its a rim/centre hit automatically from the args in the `.osu` file
 * Pretty much everything else is almost verbatim the same as the lazer implementation
 
 ## Things that could be maybe changed / need 2nd thoughts in review
 * The `Beatmap` parsing changes look kinda hacky to me atm, however doing this allows us to keep the classes ported from lazer almost completely 1:1 verbatim
   * I wouldn't be that opposed to removing the `Hit` and `HitType` and all associated classes entirely, but it would mean the other ported classes would resemble their original lazer implementations less closely (is this worth?)
 * Porting the `IBeatmapDifficultyInfo` class is probably unnecessary since I used like 1 method from it. Not sure which direction to go from here tho - should I just reduce that class to the 1 method or maybe extract that method to somewhere else?

## Testing
* I made a check in MV plugin that just emits the star rating for debugging (can be downloaded [here](https://nostril.s-ul.eu/en8Zt6tT) if you want)
* Standard SR still works (obviously based on old algorithm, but it's good enough)
* Taiko SR looks pretty accurate - sometimes it's off by like +/- 0.01 SR or so though, I'm not sure what the discrepency is but seems very trivial